### PR TITLE
Fix: issue 27

### DIFF
--- a/rpc/pool.go
+++ b/rpc/pool.go
@@ -305,7 +305,7 @@ func (a *rpcClientArray) Get(key string, pool *gettyRPCClientPool) *gettyRPCClie
 		pool.connMap.Store(key, a)
 
 		if d := now - conn.getActive(); d > pool.ttl {
-			conn.close() // -> pool.remove(c)
+			go conn.close() // -> pool.remove(c)
 			continue
 		}
 

--- a/rpc/pool.go
+++ b/rpc/pool.go
@@ -101,7 +101,7 @@ func (c *gettyRPCClient) newSession(session getty.Session) error {
 	session.SetMaxMsgLen(conf.GettySessionParam.MaxMsgLen)
 	session.SetPkgHandler(rpcClientPackageHandler)
 	session.SetEventListener(NewRpcClientHandler(c))
-	session.SetRQLen(conf.GettySessionParam.PkgRQSize)
+	// session.SetRQLen(conf.GettySessionParam.PkgRQSize)
 	session.SetWQLen(conf.GettySessionParam.PkgWQSize)
 	session.SetReadTimeout(conf.GettySessionParam.tcpReadTimeout)
 	session.SetWriteTimeout(conf.GettySessionParam.tcpWriteTimeout)
@@ -284,6 +284,12 @@ func (a *rpcClientArray) Size() int {
 func (a *rpcClientArray) Put(clt *gettyRPCClient) {
 	a.lock.Lock()
 	defer a.lock.Unlock()
+
+	for i := range a.array {
+		if a.array[i] == clt {
+			return
+		}
+	}
 
 	a.array = append(a.array, clt)
 }


### PR DESCRIPTION
* Fix:
  > issue [27](https://github.com/AlexStocks/getty/issues/27)
* Improvement:
   > the client request package sequence must be an odd number;
   > close connection asynchronously to reduce lock scope in pool.Get;