### PR TITLE
fix: closing websocket connection returns invalid status code

### DIFF
--- a/transport/connection.go
+++ b/transport/connection.go
@@ -639,7 +639,8 @@ func (w *gettyWSConn) writePong(message []byte) error {
 // close websocket connection
 func (w *gettyWSConn) close(waitSec int) {
 	w.updateWriteDeadline()
-	w.conn.WriteMessage(websocket.CloseMessage, []byte("bye-bye!!!"))
+	bytes := websocket.FormatCloseMessage(websocket.CloseNormalClosure, "bye-bye!!!")
+	w.conn.WriteMessage(websocket.CloseMessage, bytes)
 	conn := w.conn.UnderlyingConn()
 	if tcpConn, ok := conn.(*net.TCPConn); ok {
 		tcpConn.SetLinger(waitSec)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->

**What this PR does**: 修复异常关闭连接问题

**Which issue(s) this PR fixes**: [服务端关闭连接时，客户端异常关闭 #73](https://github.com/AlexStocks/getty/issues/73)
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```