### PR TITLE
fix:add read mutex in gettyWSConn(websocket) struct to prevent data race in ReadMessage() 

### DIFF
--- a/transport/connection.go
+++ b/transport/connection.go
@@ -493,8 +493,9 @@ func (u *gettyUDPConn) CloseConn(_ int) {
 
 type gettyWSConn struct {
 	gettyConn
-	conn *websocket.Conn
-	lock sync.Mutex
+	writeLock sync.Mutex
+	readLock  sync.Mutex
+	conn      *websocket.Conn
 }
 
 // create websocket connection
@@ -569,7 +570,7 @@ func (w *gettyWSConn) handlePong(string) error {
 func (w *gettyWSConn) recv() ([]byte, error) {
 	// Pls do not set read deadline when using ReadMessage. AlexStocks 20180310
 	// gorilla/websocket/conn.go:NextReader will always fail when got a timeout error.
-	_, b, e := w.conn.ReadMessage() // the first return value is message type.
+	_, b, e := w.threadSafeReadMessage() // the first return value is message type.
 	if e == nil {
 		w.readBytes.Add((uint32)(len(b)))
 	} else {
@@ -645,10 +646,21 @@ func (w *gettyWSConn) CloseConn(waitSec int) {
 
 // uses a mutex to ensure that only one thread can send a message at a time, preventing race conditions.
 func (w *gettyWSConn) threadSafeWriteMessage(messageType int, data []byte) error {
-	w.lock.Lock()
-	defer w.lock.Unlock()
+	w.writeLock.Lock()
+	defer w.writeLock.Unlock()
 	if err := w.conn.WriteMessage(messageType, data); err != nil {
 		return err
 	}
 	return nil
+}
+
+// uses a mutex to ensure that only one thread can read a message at a time, preventing race conditions.
+func (w *gettyWSConn) threadSafeReadMessage() (int, []byte, error) {
+	w.readLock.Lock()
+	defer w.readLock.Unlock()
+	messageType, readBytes, err := w.conn.ReadMessage()
+	if err != nil {
+		return messageType, nil, err
+	}
+	return messageType, readBytes, nil
 }

--- a/transport/connection.go
+++ b/transport/connection.go
@@ -644,7 +644,7 @@ func (w *gettyWSConn) CloseConn(waitSec int) {
 	w.conn.Close()
 }
 
-// uses a mutex to ensure that only one thread can send a message at a time, preventing race conditions.
+// uses a mutex(writeLock) to ensure that only one thread can send a message at a time, preventing race conditions.
 func (w *gettyWSConn) threadSafeWriteMessage(messageType int, data []byte) error {
 	w.writeLock.Lock()
 	defer w.writeLock.Unlock()
@@ -654,7 +654,7 @@ func (w *gettyWSConn) threadSafeWriteMessage(messageType int, data []byte) error
 	return nil
 }
 
-// uses a mutex to ensure that only one thread can read a message at a time, preventing race conditions.
+// uses a mutex(readLock) to ensure that only one thread can read a message at a time, preventing race conditions.
 func (w *gettyWSConn) threadSafeReadMessage() (int, []byte, error) {
 	w.readLock.Lock()
 	defer w.readLock.Unlock()


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->

**What this PR does**:
1. rename "lock" to "writeLock" and add "readLock" in gettyWSConn
2. use the "readLock" to wrap the websocket'sReadMessage function to be concurrency safe(
similar to WriteMessage（）)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
NONE
**Special notes for your reviewer**:
NONE
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```