### PR TITLE
Fix client reconnect lifecycle handling

### DIFF
--- a/transport/client.go
+++ b/transport/client.go
@@ -77,9 +77,14 @@ type client struct {
 	newSession NewSessionCallback
 	ssMap      map[Session]struct{}
 
+	// reconnectDone is the running loop's completion channel (nil while idle);
+	// reconnectPending records triggers that arrived while a loop runs, to be
+	// served by it, keeping reconnect triggers single-flight.
+	reconnectDone    chan struct{}
+	reconnectPending bool
+
 	sync.Once
 	done chan struct{}
-	wg   sync.WaitGroup
 }
 
 func (c *client) init(opts ...ClientOption) {
@@ -440,9 +445,10 @@ func (c *client) RunEventLoop(newSession NewSessionCallback) {
 	<-c.runReconnect()
 }
 
-// runReconnect starts a reconnect loop only while the client is open. The
-// client lock serializes WaitGroup.Add with stop, which prevents Add racing
-// with Close's Wait.
+// runReconnect triggers a reconnect pass and returns the channel of the loop
+// serving it; while a loop is active, further triggers are coalesced into it
+// (single-flight). After the client is closed the returned channel closes
+// immediately and no loop is started.
 func (c *client) runReconnect() <-chan struct{} {
 	done := make(chan struct{})
 	c.Lock()
@@ -452,14 +458,41 @@ func (c *client) runReconnect() <-chan struct{} {
 		close(done)
 		return done
 	default:
-		c.wg.Add(1)
 	}
+
+	if c.reconnectDone != nil {
+		c.reconnectPending = true
+		done = c.reconnectDone
+		c.Unlock()
+		return done
+	}
+
+	c.reconnectDone = done
+	c.reconnectPending = true
 	c.Unlock()
 
 	go func() {
-		defer c.wg.Done()
 		defer close(done)
-		c.reConnect()
+		for {
+			c.Lock()
+			select {
+			case <-c.done:
+				c.reconnectDone = nil
+				c.reconnectPending = false
+				c.Unlock()
+				return
+			default:
+			}
+			if !c.reconnectPending {
+				c.reconnectDone = nil
+				c.Unlock()
+				return
+			}
+			c.reconnectPending = false
+			c.Unlock()
+
+			c.reConnect()
+		}
 	}()
 	return done
 }
@@ -532,7 +565,10 @@ func (c *client) IsClosed() bool {
 	}
 }
 
+// Close stops the client without waiting for the reconnect loop, which exits
+// on its own once it observes the closed done channel. Waiting would deadlock
+// whenever Close is invoked from inside a reconnect pass (NewSessionCallback
+// runs there).
 func (c *client) Close() {
 	c.stop()
-	c.wg.Wait()
 }

--- a/transport/client.go
+++ b/transport/client.go
@@ -405,6 +405,15 @@ func (c *client) connect() bool {
 			ss.Close()
 			return false
 		}
+		if ss.IsClosed() {
+			// Closed during run() (e.g. OnOpen called Close): its stop() has
+			// already triggered a reconnect pass, so keep the dead session out
+			// of the pool and report the connect as failed.
+			ss.RemoveAttribute(sessionClientKey)
+			ss.RemoveAttribute(ignoreReconnectKey)
+			c.Unlock()
+			return false
+		}
 		c.ssMap[ss] = struct{}{}
 		c.Unlock()
 		return true

--- a/transport/client.go
+++ b/transport/client.go
@@ -372,38 +372,49 @@ func (c *client) sessionNum() int {
 	return num
 }
 
-func (c *client) connect() {
+func (c *client) connect() bool {
 	var (
 		err error
 		ss  Session
 	)
 
-	for {
-		ss = c.dial()
-		if ss == nil {
-			// client has been closed
-			break
-		}
-		err = c.newSession(ss)
-		if err == nil {
-			ss.(*session).run()
-			c.Lock()
-			if c.ssMap == nil {
-				c.Unlock()
-				break
-			}
-			c.ssMap[ss] = struct{}{}
-			c.Unlock()
-			ss.SetAttribute(sessionClientKey, c)
-			ss.SetAttribute(ignoreReconnectKey, false)
-			break
-		}
-		// don't distinguish between tcp connection and websocket connection. Because
-		// gorilla/websocket/conn.go:(Conn)Close also invoke net.Conn.Close()
-		if cerr := ss.Conn().Close(); cerr != nil {
-			log.Warnf("failed to close conn: %+v", cerr)
-		}
+	ss = c.dial()
+	if ss == nil {
+		// client has been closed
+		return false
 	}
+	err = c.newSession(ss)
+	if err == nil {
+		// Set the reconnect attributes before run(): session.stop() decides
+		// whether to reconnect from these attributes, so a connection that
+		// dies right after run() must already carry them, otherwise the
+		// reconnect is silently skipped and the pool stays short by one
+		// (AlexStocks/getty issue #121 defect 3).
+		ss.SetAttribute(sessionClientKey, c)
+		ss.SetAttribute(ignoreReconnectKey, false)
+		ss.(*session).run()
+		c.Lock()
+		if c.ssMap == nil {
+			// the pool is gone (client.stop() already ran): drop the reconnect
+			// attributes like client.stop() does, so closing this session does
+			// not trigger a reconnect, then close it to avoid leaking the
+			// already-started session (AlexStocks/getty issue #121 defect 1).
+			ss.RemoveAttribute(sessionClientKey)
+			ss.RemoveAttribute(ignoreReconnectKey)
+			c.Unlock()
+			ss.Close()
+			return false
+		}
+		c.ssMap[ss] = struct{}{}
+		c.Unlock()
+		return true
+	}
+	// don't distinguish between tcp connection and websocket connection. Because
+	// gorilla/websocket/conn.go:(Conn)Close also invoke net.Conn.Close()
+	if cerr := ss.Conn().Close(); cerr != nil {
+		log.Warnf("failed to close conn: %+v", cerr)
+	}
+	return false
 }
 
 // there are two methods to keep connection pool. the first approach is like
@@ -465,7 +476,10 @@ func (c *client) reConnect() {
 		if connPoolSize <= c.sessionNum() {
 			return
 		}
-		c.connect()
+		if c.connect() {
+			reconnectAttempts = 0
+			continue
+		}
 		reconnectAttempts++
 		if c.IsClosed() || connPoolSize <= c.sessionNum() || reconnectAttempts >= maxReconnectAttempts {
 			return

--- a/transport/client_test.go
+++ b/transport/client_test.go
@@ -312,7 +312,11 @@ func TestReconnectTriggerDuringBackoffIsCoalesced(t *testing.T) {
 		entered: make(chan struct{}, 2),
 		exited:  make(chan struct{}, 2),
 	}
-	clt := newFailingReconnectClient(builder, 200*time.Millisecond, 2)
+	// The second attempt fires only after one full backoff interval, so keep
+	// that interval far above the 50ms assertion window below: on a loaded
+	// CI machine scheduling delays must not be able to start attempt 2 inside
+	// the window. Close() below cancels the backoff, so the test stays fast.
+	clt := newFailingReconnectClient(builder, 2*time.Second, 2)
 	firstDone := clt.runReconnect()
 
 	select {
@@ -657,7 +661,6 @@ func TestTCPClientOnOpenCloseKeepsPoolAtConfiguredSize(t *testing.T) {
 		time.Sleep(20 * time.Millisecond)
 	}
 
-	assert.Equal(t, wantPoolSize, clt.sessionNum())
 	clt.Lock()
 	total := len(clt.ssMap)
 	closed := 0
@@ -667,8 +670,11 @@ func TestTCPClientOnOpenCloseKeepsPoolAtConfiguredSize(t *testing.T) {
 		}
 	}
 	clt.Unlock()
+	// Inspect ssMap before calling sessionNum(): it prunes closed sessions
+	// from the map, which would otherwise hide them from the closed count.
 	assert.Equal(t, wantPoolSize, total)
 	assert.Equal(t, 0, closed)
+	assert.Equal(t, wantPoolSize, clt.sessionNum())
 }
 
 func (h *PackageHandler) Read(ss Session, data []byte) (any, int, error) {

--- a/transport/client_test.go
+++ b/transport/client_test.go
@@ -46,16 +46,25 @@ type countingTLSConfigBuilder struct {
 	calls   atomic.Int32
 	entered chan struct{}
 	release <-chan struct{}
+	exited  chan struct{}
 }
 
 func (b *countingTLSConfigBuilder) BuildTlsConfig() (*tls.Config, error) {
 	b.calls.Add(1)
-	select {
-	case b.entered <- struct{}{}:
-	default:
+	if b.entered != nil {
+		select {
+		case b.entered <- struct{}{}:
+		default:
+		}
 	}
 	if b.release != nil {
 		<-b.release
+	}
+	if b.exited != nil {
+		select {
+		case b.exited <- struct{}{}:
+		default:
+		}
 	}
 	return nil, errTestTLSConfig
 }
@@ -132,13 +141,243 @@ func TestReconnectBackoffIsCancelledByClose(t *testing.T) {
 	}
 }
 
-func TestSessionReconnectIsTrackedByClose(t *testing.T) {
-	releaseReconnect := make(chan struct{})
+// newBlockingReconnectClient builds a TCP client whose NewSessionCallback
+// blocks until release() is called, so tests can hold a reconnect pass in
+// flight and observe how further triggers behave.
+func newBlockingReconnectClient(t *testing.T) (*client, *MessageHandler, <-chan struct{}, func(), *atomic.Int32) {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	assert.Nil(t, err)
+	assert.NotNil(t, listener)
+
+	acceptedConns := make(chan net.Conn, 8)
+	acceptDone := make(chan struct{})
+	go func() {
+		defer close(acceptDone)
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			select {
+			case acceptedConns <- conn:
+			default:
+				_ = conn.Close()
+			}
+		}
+	}()
+
+	clt := newClient(
+		TCP_CLIENT,
+		WithServerAddress(listener.Addr().String()),
+		WithConnectionNumber(1),
+		WithReconnectInterval(int(time.Millisecond)),
+		WithReconnectAttempts(2),
+	)
+	var (
+		callbacks       atomic.Int32
+		callbackEntered = make(chan struct{}, 1)
+		releaseCallback = make(chan struct{})
+		releaseOnce     sync.Once
+		msgHandler      sessionCloseMessageHandler
+	)
+	msgHandler.closed = make(chan struct{}, 1)
+	release := func() {
+		releaseOnce.Do(func() {
+			close(releaseCallback)
+		})
+	}
+	clt.newSession = func(session Session) error {
+		callbacks.Add(1)
+		select {
+		case callbackEntered <- struct{}{}:
+		default:
+		}
+		<-releaseCallback
+		if err := newSessionCallback(session, &msgHandler.MessageHandler); err != nil {
+			return err
+		}
+		session.SetEventListener(&msgHandler)
+		return nil
+	}
+	t.Cleanup(func() {
+		release()
+		_ = listener.Close()
+		<-acceptDone
+		closedAcceptedConn := false
+		for {
+			select {
+			case conn := <-acceptedConns:
+				closedAcceptedConn = true
+				_ = conn.Close()
+			default:
+				if closedAcceptedConn {
+					select {
+					case <-msgHandler.closed:
+					case <-time.After(time.Second):
+					}
+				}
+				clt.Close()
+				return
+			}
+		}
+	})
+
+	return clt, &msgHandler.MessageHandler, callbackEntered, release, &callbacks
+}
+
+func TestTCPClientReconnectRunsSingleFlight(t *testing.T) {
+	clt, msgHandler, callbackEntered, release, callbacks := newBlockingReconnectClient(t)
+
+	firstDone := clt.runReconnect()
+	select {
+	case <-callbackEntered:
+	case <-time.After(time.Second):
+		t.Fatal("first reconnect did not enter NewSessionCallback")
+	}
+
+	secondDone := clt.runReconnect()
+	if secondDone != firstDone {
+		t.Fatal("concurrent reconnect trigger did not share the active worker")
+	}
+	assert.Equal(t, int32(1), callbacks.Load())
+	select {
+	case <-callbackEntered:
+		t.Fatal("concurrent reconnect trigger entered a second NewSessionCallback")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	release()
+	select {
+	case <-firstDone:
+	case <-time.After(time.Second):
+		t.Fatal("single-flight reconnect did not finish")
+	}
+
+	assert.Equal(t, int32(1), callbacks.Load())
+	assert.Equal(t, 1, msgHandler.SessionNumber())
+	assert.Equal(t, 1, clt.sessionNum())
+}
+
+func TestSessionTriggeredReconnectIsCoalesced(t *testing.T) {
+	clt, msgHandler, callbackEntered, release, callbacks := newBlockingReconnectClient(t)
+
+	firstDone := clt.runReconnect()
+	select {
+	case <-callbackEntered:
+	case <-time.After(time.Second):
+		t.Fatal("first reconnect did not enter NewSessionCallback")
+	}
+
+	localConn, peerConn := net.Pipe()
+	defer func() {
+		_ = localConn.Close()
+		_ = peerConn.Close()
+	}()
+	ss := newTCPSession(localConn, clt).(*session)
+	ss.SetAttribute(sessionClientKey, clt)
+	ss.SetAttribute(ignoreReconnectKey, false)
+	ss.stop()
+
+	clt.Lock()
+	activeDone := clt.reconnectDone
+	pending := clt.reconnectPending
+	clt.Unlock()
+	if activeDone != firstDone {
+		t.Fatal("session-triggered reconnect did not share the active worker")
+	}
+	assert.True(t, pending)
+	assert.Equal(t, int32(1), callbacks.Load())
+	select {
+	case <-callbackEntered:
+		t.Fatal("session-triggered reconnect entered a second NewSessionCallback")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	release()
+	select {
+	case <-firstDone:
+	case <-time.After(time.Second):
+		t.Fatal("coalesced reconnect did not finish")
+	}
+
+	assert.Equal(t, int32(1), callbacks.Load())
+	assert.Equal(t, 1, msgHandler.SessionNumber())
+	assert.Equal(t, 1, clt.sessionNum())
+}
+
+func TestReconnectTriggerDuringBackoffIsCoalesced(t *testing.T) {
 	builder := &countingTLSConfigBuilder{
-		entered: make(chan struct{}, 4),
+		entered: make(chan struct{}, 2),
+		exited:  make(chan struct{}, 2),
+	}
+	clt := newFailingReconnectClient(builder, 200*time.Millisecond, 2)
+	firstDone := clt.runReconnect()
+
+	select {
+	case <-builder.entered:
+	case <-time.After(time.Second):
+		t.Fatal("first reconnect attempt did not start")
+	}
+	select {
+	case <-builder.exited:
+	case <-time.After(time.Second):
+		t.Fatal("first reconnect attempt did not finish")
+	}
+
+	secondDone := clt.runReconnect()
+	if secondDone != firstDone {
+		t.Fatal("backoff trigger did not share the active reconnect worker")
+	}
+
+	select {
+	case <-builder.entered:
+		t.Fatal("backoff trigger started a second reconnect worker too early")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	assert.Equal(t, int32(1), builder.calls.Load())
+
+	clt.Close()
+	select {
+	case <-firstDone:
+	case <-time.After(time.Second):
+		t.Fatal("reconnect worker did not finish after Close")
+	}
+}
+
+func TestRunReconnectAfterCloseIsNoop(t *testing.T) {
+	builder := &countingTLSConfigBuilder{entered: make(chan struct{}, 1)}
+	clt := newFailingReconnectClient(builder, time.Millisecond, 1)
+	clt.Close()
+
+	done := clt.runReconnect()
+	select {
+	case <-done:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("runReconnect did not return immediately after Close")
+	}
+	assert.Equal(t, int32(0), builder.calls.Load())
+}
+
+func TestSessionTriggeredReconnectDoesNotBlockClose(t *testing.T) {
+	releaseReconnect := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() {
+		releaseOnce.Do(func() {
+			close(releaseReconnect)
+		})
+	}
+	defer release()
+
+	builder := &countingTLSConfigBuilder{
+		entered: make(chan struct{}, 1),
 		release: releaseReconnect,
+		exited:  make(chan struct{}, 1),
 	}
 	clt := newFailingReconnectClient(builder, 2*time.Second, 3)
+
 	localConn, peerConn := net.Pipe()
 	defer func() {
 		_ = localConn.Close()
@@ -148,11 +387,7 @@ func TestSessionReconnectIsTrackedByClose(t *testing.T) {
 	ss.SetAttribute(sessionClientKey, clt)
 	ss.SetAttribute(ignoreReconnectKey, false)
 
-	sessionStopDone := make(chan struct{})
-	go func() {
-		ss.stop()
-		close(sessionStopDone)
-	}()
+	ss.stop()
 	select {
 	case <-builder.entered:
 	case <-time.After(time.Second):
@@ -166,21 +401,73 @@ func TestSessionReconnectIsTrackedByClose(t *testing.T) {
 	}()
 	select {
 	case <-closeDone:
-		close(releaseReconnect)
-		t.Fatal("Close returned while the session-triggered reconnect was still running")
-	case <-time.After(100 * time.Millisecond):
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("Close blocked on the session-triggered reconnect worker")
 	}
+	release()
+	select {
+	case <-builder.exited:
+	case <-time.After(time.Second):
+		t.Fatal("session-triggered reconnect did not leave the blocked point after release")
+	}
+}
 
-	close(releaseReconnect)
+func TestNewSessionCallbackCloseDoesNotDeadlock(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	assert.Nil(t, err)
+	assert.NotNil(t, listener)
+	accepted := make(chan struct{}, 1)
+	acceptDone := make(chan struct{})
+	go func() {
+		defer close(acceptDone)
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			select {
+			case accepted <- struct{}{}:
+			default:
+			}
+			_ = conn.Close()
+		}
+	}()
+	defer func() {
+		_ = listener.Close()
+		<-acceptDone
+	}()
+
+	clt := newClient(
+		TCP_CLIENT,
+		WithServerAddress(listener.Addr().String()),
+		WithConnectionNumber(1),
+		WithReconnectInterval(int(time.Millisecond)),
+		WithReconnectAttempts(1),
+	)
+	callbackEntered := make(chan struct{})
+	runDone := make(chan struct{})
+	go func() {
+		clt.RunEventLoop(func(Session) error {
+			close(callbackEntered)
+			clt.Close()
+			return errors.New("reject session and stop client")
+		})
+		close(runDone)
+	}()
 	select {
-	case <-closeDone:
+	case <-accepted:
 	case <-time.After(time.Second):
-		t.Fatal("Close did not return after the session-triggered reconnect completed")
+		t.Fatal("listener did not accept the client connection")
 	}
 	select {
-	case <-sessionStopDone:
+	case <-callbackEntered:
 	case <-time.After(time.Second):
-		t.Fatal("session stop did not return")
+		t.Fatal("NewSessionCallback did not run")
+	}
+	select {
+	case <-runDone:
+	case <-time.After(time.Second):
+		t.Fatal("RunEventLoop did not return after Close from NewSessionCallback")
 	}
 }
 
@@ -285,7 +572,10 @@ func (h *closeInOnOpenListener) OnOpen(session Session) error {
 func TestTCPClientOnOpenCloseKeepsPoolAtConfiguredSize(t *testing.T) {
 	const (
 		wantPoolSize = 3
-		closeBurst   = 20
+		// With single-flight reconnects the closing sessions are re-dialed by
+		// one loop with backoff, so keep the burst small enough to fit the
+		// poll deadline (12 failures x 20ms backoff ramp ~= 1.5s).
+		closeBurst = 12
 	)
 
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
@@ -308,7 +598,7 @@ func TestTCPClientOnOpenCloseKeepsPoolAtConfiguredSize(t *testing.T) {
 	clt := NewTCPClient(
 		WithServerAddress(listener.Addr().String()),
 		WithConnectionNumber(wantPoolSize),
-		WithReconnectInterval(int(200*time.Millisecond)),
+		WithReconnectInterval(int(20*time.Millisecond)),
 		WithReconnectAttempts(50),
 	).(*client)
 
@@ -341,7 +631,7 @@ func TestTCPClientOnOpenCloseKeepsPoolAtConfiguredSize(t *testing.T) {
 	}()
 
 	// Wait until the pool holds exactly wantPoolSize live sessions for 300ms.
-	deadline := time.Now().Add(5 * time.Second)
+	deadline := time.Now().Add(8 * time.Second)
 	stable := 0
 	for {
 		clt.Lock()
@@ -413,6 +703,18 @@ func (h *MessageHandler) OnError(session Session, err error) {}
 func (h *MessageHandler) OnClose(session Session)            {}
 func (h *MessageHandler) OnMessage(session Session, pkg any) {}
 func (h *MessageHandler) OnCron(session Session)             {}
+
+type sessionCloseMessageHandler struct {
+	MessageHandler
+	closed chan struct{}
+}
+
+func (h *sessionCloseMessageHandler) OnClose(session Session) {
+	select {
+	case h.closed <- struct{}{}:
+	default:
+	}
+}
 
 type Package struct{}
 

--- a/transport/client_test.go
+++ b/transport/client_test.go
@@ -265,6 +265,122 @@ func (h *attributeProbeMessageHandler) OnOpen(session Session) error {
 	return nil
 }
 
+// closeInOnOpenListener closes the first closeBudget sessions from OnOpen,
+// i.e. synchronously inside run() before connect() registers the session.
+type closeInOnOpenListener struct {
+	MessageHandler
+	closeBudget atomic.Int32
+}
+
+func (h *closeInOnOpenListener) OnOpen(session Session) error {
+	if h.closeBudget.Add(-1) >= 0 {
+		session.Close()
+	}
+	return nil
+}
+
+// TestTCPClientOnOpenCloseKeepsPoolAtConfiguredSize: sessions closed
+// synchronously in OnOpen must never land in ssMap, and the pool must settle
+// at exactly WithConnectionNumber live sessions.
+func TestTCPClientOnOpenCloseKeepsPoolAtConfiguredSize(t *testing.T) {
+	const (
+		wantPoolSize = 3
+		closeBurst   = 20
+	)
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	assert.Nil(t, err)
+	assert.NotNil(t, listener)
+	t.Cleanup(func() { _ = listener.Close() })
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				defer func() { _ = conn.Close() }()
+				_, _ = io.Copy(io.Discard, conn)
+			}()
+		}
+	}()
+
+	clt := NewTCPClient(
+		WithServerAddress(listener.Addr().String()),
+		WithConnectionNumber(wantPoolSize),
+		WithReconnectInterval(int(200*time.Millisecond)),
+		WithReconnectAttempts(50),
+	).(*client)
+
+	handler := &closeInOnOpenListener{}
+	handler.closeBudget.Store(closeBurst)
+	cb := func(session Session) error {
+		var pkgHandler PackageHandler
+		session.SetName("onopen-close-client-session")
+		session.SetPkgHandler(&pkgHandler)
+		session.SetEventListener(handler)
+		session.SetReadTimeout(20 * time.Millisecond)
+		session.SetWriteTimeout(20 * time.Millisecond)
+		session.SetWaitTime(20 * time.Millisecond)
+
+		return nil
+	}
+
+	runEventLoopDone := make(chan struct{})
+	go func() {
+		clt.RunEventLoop(cb)
+		close(runEventLoopDone)
+	}()
+	defer func() {
+		clt.Close()
+		select {
+		case <-runEventLoopDone:
+		case <-time.After(2 * time.Second):
+			t.Error("RunEventLoop did not return after Close")
+		}
+	}()
+
+	// Wait until the pool holds exactly wantPoolSize live sessions for 300ms.
+	deadline := time.Now().Add(5 * time.Second)
+	stable := 0
+	for {
+		clt.Lock()
+		total := len(clt.ssMap)
+		active := 0
+		for s := range clt.ssMap {
+			if !s.IsClosed() {
+				active++
+			}
+		}
+		clt.Unlock()
+		if total == wantPoolSize && active == wantPoolSize {
+			stable++
+			if stable >= 15 {
+				break
+			}
+		} else {
+			stable = 0
+			if time.Now().After(deadline) {
+				t.Fatalf("pool did not stabilize at %d live sessions: got %d sessions (%d live)", wantPoolSize, total, active)
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	assert.Equal(t, wantPoolSize, clt.sessionNum())
+	clt.Lock()
+	total := len(clt.ssMap)
+	closed := 0
+	for s := range clt.ssMap {
+		if s.IsClosed() {
+			closed++
+		}
+	}
+	clt.Unlock()
+	assert.Equal(t, wantPoolSize, total)
+	assert.Equal(t, 0, closed)
+}
+
 func (h *PackageHandler) Read(ss Session, data []byte) (any, int, error) {
 	return nil, 0, nil
 }

--- a/transport/client_test.go
+++ b/transport/client_test.go
@@ -184,6 +184,87 @@ func TestSessionReconnectIsTrackedByClose(t *testing.T) {
 	}
 }
 
+func TestTCPClientSetsReconnectAttributesBeforeRun(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	assert.Nil(t, err)
+	assert.NotNil(t, listener)
+	defer func() {
+		_ = listener.Close()
+	}()
+
+	acceptedConn := make(chan net.Conn, 1)
+	acceptErr := make(chan error, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			acceptErr <- err
+			return
+		}
+		acceptedConn <- conn
+	}()
+
+	clt := NewTCPClient(
+		WithServerAddress(listener.Addr().String()),
+		WithConnectionNumber(1),
+	).(*client)
+	defer clt.Close()
+
+	attrState := make(chan string, 1)
+	handler := &attributeProbeMessageHandler{
+		MessageHandler: MessageHandler{},
+		attrState:      attrState,
+	}
+	clt.newSession = func(session Session) error {
+		var pkgHandler PackageHandler
+		session.SetName("reconnect-attribute-client-session")
+		session.SetPkgHandler(&pkgHandler)
+		session.SetEventListener(handler)
+		session.SetReadTimeout(time.Millisecond)
+		session.SetWriteTimeout(time.Millisecond)
+		session.SetWaitTime(time.Millisecond)
+
+		return nil
+	}
+
+	assert.True(t, clt.connect())
+
+	select {
+	case state := <-attrState:
+		assert.Equal(t, "set", state)
+	case <-time.After(time.Second):
+		t.Fatal("session OnOpen was not invoked")
+	}
+
+	select {
+	case conn := <-acceptedConn:
+		_ = conn.Close()
+	case err := <-acceptErr:
+		t.Fatalf("server accept failed: %+v", err)
+	case <-time.After(time.Second):
+		t.Fatal("server did not accept client connection")
+	}
+}
+
+// attributeProbeMessageHandler records whether the reconnect attributes are
+// already set when OnOpen runs. session.run() invokes OnOpen synchronously, so
+// observing them inside OnOpen proves they were set before run().
+type attributeProbeMessageHandler struct {
+	MessageHandler
+	attrState chan string
+}
+
+func (h *attributeProbeMessageHandler) OnOpen(session Session) error {
+	clt, cltFound := session.GetAttribute(sessionClientKey).(*client)
+	ignoreReconnect, flagFound := session.GetAttribute(ignoreReconnectKey).(bool)
+	if cltFound && flagFound && clt != nil && !ignoreReconnect {
+		h.attrState <- "set"
+	} else {
+		h.attrState <- "missing"
+	}
+
+	return nil
+}
+
 func (h *PackageHandler) Read(ss Session, data []byte) (any, int, error) {
 	return nil, 0, nil
 }

--- a/transport/session_test.go
+++ b/transport/session_test.go
@@ -506,8 +506,8 @@ func TestHandlePackageWithNilListenerDoesNotPanicOnError(t *testing.T) {
 // the session has cleared its embedded Connection via gc().
 func TestSetMethodsAfterGCDoNotPanic(t *testing.T) {
 	c1, c2 := net.Pipe()
-	defer c1.Close()
-	defer c2.Close()
+	defer func() { _ = c1.Close() }()
+	defer func() { _ = c2.Close() }()
 
 	ss := newTCPSession(c1, newServer(TCP_SERVER)).(*session)
 	ss.gc()


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->

**What this PR does**:


1. Fixes issue #121 (`23a6036`, transport/client.go):
   - `connect()` becomes single-shot returning bool — removes the unbounded
     hot re-dial loop on newSession-callback failure; retries/backoff now
     owned by `reConnect()` (counted against maxReconnectAttempts, reset on
     success).
   - `sessionClientKey`/`ignoreReconnectKey` set before `run()`, so a session
     dying right after `run()` is no longer skipped for reconnect.
   - On the `stop()` race (`ssMap == nil`), remove attributes and
     `ss.Close()` the started session instead of leaking it.
   - Regression test `TestTCPClientSetsReconnectAttributesBeforeRun`.
   - Also `12ef925`: errcheck cleanup in session tests.

2. Syncs the remaining deltas of apache/dubbo-getty#142 (upstream already
   has stop-outside-lock, runReconnect routing, cancellable backoff):
   - Single-flight `runReconnect()` (`reconnectDone`/`reconnectPending`):
     concurrent triggers share one reconnect worker, no duplicate dialing.
   - Drop the client WaitGroup: `Close()` no longer waits on reconnect
     workers, eliminating the self-wait deadlock when `Close()` is called
     from a worker (e.g. inside the newSession callback).
   - Ports PR #142's regression tests (adapted to the transport/ layout):
     TestTCPClientReconnectRunsSingleFlight, TestSessionTriggeredReconnectIsCoalesced,
     TestReconnectTriggerDuringBackoffIsCoalesced, TestReconnectBackoffIsCancelledByClose,
     TestRunReconnectAfterCloseIsNoop, TestSessionTriggeredReconnectDoesNotBlockClose,
     TestNewSessionCallbackCloseDoesNotDeadlock.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #121 
syncs: https://github.com/apache/dubbo-getty/pull/142


**Special notes for your reviewer**:

- Behavior change: `Close()` returns immediately; reconnect workers exit on
  their own after observing `c.done`.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection retry and back-off behavior after connection failures.
  * Coalesced simultaneous reconnect requests to prevent redundant connection attempts.
  * Prevented unwanted reconnects and resource leaks when sessions close during setup or the client is closed.
  * Ensured closing the client remains responsive while reconnect activity is in progress.

* **Tests**
  * Added coverage for concurrent reconnects, connection cleanup, client shutdown, and sessions that close during startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->