### PR TITLE
fix: session write-path lock discipline — packetLock for Send, snapshot-only s.lock

### DIFF
--- a/transport/session.go
+++ b/transport/session.go
@@ -1256,10 +1256,24 @@ func (s *session) Send(pkg any) (int, error) {
 	if s == nil {
 		return 0, nil
 	}
+	// #131: Send is a public write entry point and must join the same packetLock
+	// domain as WriteBytes/WritePkg. Without it, a direct Send can slip between
+	// the maxPacketLen-sized fragments of a concurrent WriteBytes (corrupting the
+	// peer's byte stream framing) or run inside the temporary write-timeout
+	// window that WritePkg(timeout>0) owns via packetLock.Lock.
+	// A read lock is enough: Send performs exactly one conn.Send, so it only has
+	// to be mutually exclusive with the fragmenting (write-locked) writer.
+	s.packetLock.RLock()
+	defer s.packetLock.RUnlock()
+	// Snapshot the connection under s.lock and release it before conn.Send:
+	// gettyUDPConn.Send calls back s.EndPoint(), which takes s.lock.RLock again,
+	// and a recursive RLock can deadlock behind a queued writer. This mirrors
+	// WriteBytes/WritePkg, which also only hold s.lock for the snapshot.
 	s.lock.RLock()
-	defer s.lock.RUnlock()
-	if s.Connection != nil {
-		return s.Connection.Send(pkg)
+	conn := s.Connection
+	s.lock.RUnlock()
+	if conn != nil {
+		return conn.Send(pkg)
 	}
 	return 0, nil
 }

--- a/transport/session.go
+++ b/transport/session.go
@@ -291,15 +291,27 @@ func (s *session) Reset() {
 }
 
 func (s *session) Conn() net.Conn {
-	if tc, ok := s.Connection.(*gettyTCPConn); ok {
+	// #112: gc()/Reset() nil s.Connection under s.lock, so read it under s.lock
+	// too. Only the field access is guarded; the returned net.Conn is immutable
+	// after construction (closed via closeOnce), so it stays usable.
+	s.lock.RLock()
+	conn := s.Connection
+	s.lock.RUnlock()
+	return netConnOf(conn)
+}
+
+// netConnOf unwraps the net.Conn behind a Connection snapshot. The caller is
+// responsible for having read the snapshot under s.lock.
+func netConnOf(conn Connection) net.Conn {
+	if tc, ok := conn.(*gettyTCPConn); ok {
 		return tc.conn
 	}
 
-	if uc, ok := s.Connection.(*gettyUDPConn); ok {
+	if uc, ok := conn.(*gettyUDPConn); ok {
 		return uc.conn
 	}
 
-	if wc, ok := s.Connection.(*gettyWSConn); ok {
+	if wc, ok := conn.(*gettyWSConn); ok {
 		return wc.conn.UnderlyingConn()
 	}
 
@@ -313,15 +325,28 @@ func (s *session) EndPoint() EndPoint {
 }
 
 func (s *session) gettyConn() *gettyConn {
-	if tc, ok := s.Connection.(*gettyTCPConn); ok {
+	// #112: same field-snapshot rule as Conn(): gc()/Reset() write s.Connection
+	// under s.lock.
+	s.lock.RLock()
+	conn := s.Connection
+	s.lock.RUnlock()
+	return gettyConnOf(conn)
+}
+
+// gettyConnOf unwraps the *gettyConn behind a Connection snapshot. The caller
+// is responsible for having read the snapshot under s.lock; callers that
+// already hold a snapshot (WritePkg) must use this instead of gettyConn() to
+// avoid a recursive RLock.
+func gettyConnOf(conn Connection) *gettyConn {
+	if tc, ok := conn.(*gettyTCPConn); ok {
 		return &(tc.gettyConn)
 	}
 
-	if uc, ok := s.Connection.(*gettyUDPConn); ok {
+	if uc, ok := conn.(*gettyUDPConn); ok {
 		return &(uc.gettyConn)
 	}
 
-	if wc, ok := s.Connection.(*gettyWSConn); ok {
+	if wc, ok := conn.(*gettyWSConn); ok {
 		return &(wc.gettyConn)
 	}
 
@@ -544,8 +569,10 @@ func (s *session) WritePkg(pkg any, timeout time.Duration) (pkgBytesLenth int, s
 	// gc() later nils the field, because they reference the underlying obj.
 	s.lock.RLock()
 	conn := s.Connection
-	gc := s.gettyConn()
 	s.lock.RUnlock()
+	// #112: unwrap from the snapshot taken above; calling s.gettyConn() here
+	// would take s.lock again.
+	gc := gettyConnOf(conn)
 	if conn == nil || gc == nil {
 		return 0, 0, ErrSessionClosed
 	}
@@ -1156,7 +1183,10 @@ func (s *session) gc() {
 			defer lifecycle.release()
 		}
 		if conn != nil {
-			conn.CloseConn(int(wait))
+			// #112: CloseConn takes seconds, but wait is a time.Duration in
+			// nanoseconds: int(wait) overflowed the int32 linger field and made
+			// Close() block for minutes instead of the pending duration.
+			conn.CloseConn(int(wait / time.Second))
 		}
 	}(conn, wait, lifecycle)
 }
@@ -1286,6 +1316,21 @@ func (s *session) ReadTimeout() time.Duration {
 	defer s.lock.RUnlock()
 	if s.Connection != nil {
 		return s.Connection.ReadTimeout()
+	}
+	return time.Duration(0)
+}
+
+// WriteTimeout mirrors ReadTimeout. Without it the promoted Connection method
+// was called directly, so stop() panicked once gc()/Reset() had nil-ed
+// s.Connection (issue #112).
+func (s *session) WriteTimeout() time.Duration {
+	if s == nil {
+		return time.Duration(0)
+	}
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	if s.Connection != nil {
+		return s.Connection.WriteTimeout()
 	}
 	return time.Duration(0)
 }

--- a/transport/session_test.go
+++ b/transport/session_test.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"math"
 	"net"
+	"reflect"
 	"strconv"
 	"sync"
 	"testing"
@@ -279,6 +280,129 @@ func (*resetBarrierNetConn) SetWriteDeadline(time.Time) error { return nil }
 
 func (c *resetBarrierNetConn) releaseRead() {
 	c.releaseOnce.Do(func() { close(c.release) })
+}
+
+// fragmentGateNetConn records the size of every Write and parks the first one
+// until released, so a test can freeze WriteBytes inside its maxPacketLen
+// fragmenting loop and observe whether another writer slips in.
+type fragmentGateNetConn struct {
+	mu           sync.Mutex
+	writes       []int
+	entered      chan int
+	releaseFirst chan struct{}
+	firstOnce    sync.Once
+	firstDone    chan struct{}
+}
+
+func newFragmentGateNetConn() *fragmentGateNetConn {
+	return &fragmentGateNetConn{
+		entered:      make(chan int, 8),
+		releaseFirst: make(chan struct{}),
+		firstDone:    make(chan struct{}),
+	}
+}
+
+func (c *fragmentGateNetConn) Write(p []byte) (int, error) {
+	c.mu.Lock()
+	c.writes = append(c.writes, len(p))
+	c.mu.Unlock()
+	c.entered <- len(p)
+	c.firstOnce.Do(func() {
+		<-c.releaseFirst
+		close(c.firstDone)
+	})
+	<-c.firstDone
+	return len(p), nil
+}
+
+func (*fragmentGateNetConn) Read([]byte) (int, error)         { return 0, io.EOF }
+func (*fragmentGateNetConn) Close() error                     { return nil }
+func (*fragmentGateNetConn) LocalAddr() net.Addr              { return &net.TCPAddr{} }
+func (*fragmentGateNetConn) RemoteAddr() net.Addr             { return &net.TCPAddr{} }
+func (*fragmentGateNetConn) SetDeadline(time.Time) error      { return nil }
+func (*fragmentGateNetConn) SetReadDeadline(time.Time) error  { return nil }
+func (*fragmentGateNetConn) SetWriteDeadline(time.Time) error { return nil }
+
+func (c *fragmentGateNetConn) writeSizes() []int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]int(nil), c.writes...)
+}
+
+// TestSendWaitsForWriteBytesFragments is the regression for issue #131: a
+// public session.Send must not interleave with the maxPacketLen-sized fragments
+// of a concurrent WriteBytes, otherwise the peer decodes a corrupted byte
+// stream. The gate freezes WriteBytes after its first fragment, so the write
+// order is observed deterministically instead of by timing luck.
+func TestSendWaitsForWriteBytesFragments(t *testing.T) {
+	netConn := newFragmentGateNetConn()
+	ss := newTCPSession(netConn, nil).(*session)
+
+	bigDone := make(chan error, 1)
+	go func() {
+		_, err := ss.WriteBytes(make([]byte, maxPacketLen+1))
+		bigDone <- err
+	}()
+
+	select {
+	case n := <-netConn.entered:
+		if n != maxPacketLen {
+			t.Fatalf("first fragment size = %d, want %d", n, maxPacketLen)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("WriteBytes did not enter the first fragment")
+	}
+
+	sendDone := make(chan error, 1)
+	go func() {
+		_, err := ss.Send([]byte("direct"))
+		sendDone <- err
+	}()
+
+	select {
+	case n := <-netConn.entered:
+		close(netConn.releaseFirst)
+		<-bigDone
+		<-sendDone
+		t.Fatalf("Send wrote %d bytes while a WriteBytes fragment was in flight", n)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(netConn.releaseFirst)
+	if err := <-bigDone; err != nil {
+		t.Fatalf("WriteBytes failed: %v", err)
+	}
+
+	select {
+	case n := <-netConn.entered:
+		if n != 1 {
+			t.Fatalf("WriteBytes trailing fragment size = %d, want 1", n)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("WriteBytes did not write its trailing fragment")
+	}
+
+	select {
+	case err := <-sendDone:
+		if err != nil {
+			t.Fatalf("Send failed: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Send did not complete after WriteBytes released packetLock")
+	}
+
+	select {
+	case n := <-netConn.entered:
+		if n != len("direct") {
+			t.Fatalf("direct Send wrote %d bytes, want %d", n, len("direct"))
+		}
+	case <-time.After(time.Second):
+		t.Fatal("direct Send never reached the connection")
+	}
+
+	if got, want := netConn.writeSizes(), []int{maxPacketLen, 1, len("direct")}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("wire write order = %v, want %v", got, want)
+	}
 }
 
 func TestConcurrentWritePkgTimeoutRestoration(t *testing.T) {

--- a/transport/session_test.go
+++ b/transport/session_test.go
@@ -726,3 +726,128 @@ func TestRepeatStopWaitsForCloseSequence(t *testing.T) {
 		t.Fatal("first stop() did not return")
 	}
 }
+
+// closeConnRecorder captures the waitSec handed to Connection.CloseConn.
+type closeConnRecorder struct {
+	*gettyTCPConn
+	waits chan int
+}
+
+func (c *closeConnRecorder) CloseConn(waitSec int) {
+	c.waits <- waitSec
+}
+
+// endPointCallbackConn mimics gettyUDPConn.Send, which calls back
+// session.EndPoint() and therefore re-enters s.lock (issue #112).
+type endPointCallbackConn struct {
+	*gettyTCPConn
+	ss     *session
+	locked chan bool
+}
+
+func (c *endPointCallbackConn) Send(pkg any) (int, error) {
+	// A writer's TryLock fails while any reader holds s.lock, so this reports
+	// whether session.Send kept s.lock held across the Connection call.
+	acquired := c.ss.lock.TryLock()
+	if acquired {
+		c.ss.lock.Unlock()
+	}
+	c.locked <- acquired
+	_ = c.ss.EndPoint() // the recursive RLock that deadlocked before the fix
+	body, _ := pkg.([]byte)
+	return len(body), nil
+}
+
+// Regression test for #112: session.Send used to hold s.lock across
+// Connection.Send. gettyUDPConn.Send calls back EndPoint(), which takes
+// s.lock.RLock again, and that recursive RLock deadlocks behind a queued
+// writer. The stub reports the lock state from inside the call, so no timing
+// luck is involved.
+func TestSendDoesNotHoldSessionLockAcrossConnectionSend(t *testing.T) {
+	conn := &endPointCallbackConn{
+		gettyTCPConn: newGettyTCPConn(&eofDataNetConn{}),
+		locked:       make(chan bool, 1),
+	}
+	ss := newSession(newServer(UDP_ENDPOINT), conn)
+	conn.ss = ss
+
+	if _, err := ss.Send([]byte("direct")); err != nil {
+		t.Fatalf("Send failed: %v", err)
+	}
+	if acquired := <-conn.locked; !acquired {
+		t.Fatal("session.Send held s.lock across Connection.Send: EndPoint() would recurse and deadlock behind a queued writer")
+	}
+}
+
+// Regression test for #112: gc() passed the pending duration to CloseConn
+// without converting nanoseconds to seconds, so int(wait) overflowed the
+// int32 linger field and Close blocked for minutes.
+func TestGCClosesConnWithSeconds(t *testing.T) {
+	rec := &closeConnRecorder{
+		gettyTCPConn: newGettyTCPConn(&eofDataNetConn{}),
+		waits:        make(chan int, 1),
+	}
+	ss := newSession(nil, rec)
+
+	ss.gc()
+
+	select {
+	case waitSec := <-rec.waits:
+		if want := int(pendingDuration / time.Second); waitSec != want {
+			t.Fatalf("CloseConn waitSec = %d, want %d (seconds, not nanoseconds)", waitSec, want)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("gc() did not call Connection.CloseConn")
+	}
+}
+
+// Regression test for #112: WriteTimeout used to be the promoted Connection
+// method with no nil guard, so stop() crashed once gc()/Reset() had cleared
+// s.Connection.
+func TestWriteTimeoutIsNilSafeAfterReset(t *testing.T) {
+	ss := newTCPSession(&eofDataNetConn{}, newServer(TCP_SERVER)).(*session)
+	ss.Reset()
+
+	if got := ss.WriteTimeout(); got != 0 {
+		t.Fatalf("WriteTimeout after Reset = %v, want 0", got)
+	}
+}
+
+// Regression test for #112: Conn()/Stat() read s.Connection without s.lock
+// while gc()/Reset() write it. Relies on the race detector (CI runs
+// `make test-race`).
+func TestStatAndConnAreSafeDuringGC(t *testing.T) {
+	ss := newTCPSession(&eofDataNetConn{}, newServer(TCP_SERVER)).(*session)
+
+	// Both goroutines are released by the same barrier and joined before the
+	// test returns: the reads are guaranteed to overlap the write rather than
+	// possibly finishing first, and neither goroutine outlives the test.
+	start := make(chan struct{})
+	readsDone := make(chan struct{})
+	gcDone := make(chan struct{})
+	go func() {
+		defer close(readsDone)
+		<-start
+		for i := 0; i < 1000; i++ {
+			_ = ss.Stat()
+			_ = ss.Conn()
+		}
+	}()
+	go func() {
+		defer close(gcDone)
+		<-start
+		ss.gc()
+	}()
+	close(start)
+
+	select {
+	case <-gcDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("gc() did not return")
+	}
+	select {
+	case <-readsDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Stat/Conn did not return while gc() was running")
+	}
+}


### PR DESCRIPTION
Fixes #131. Fixes #112.

Both issues are the same class of bug: `s.lock` was held for longer than the field snapshot it protects, and one write entry point sat outside the `packetLock` domain.

## #131 — `session.Send` could split `WriteBytes` fragments

`session.Send` is a public write entry point (`Session` embeds `Connection`), but it called `conn.Send` without entering the `packetLock` domain:

1. **Byte-stream corruption.** A direct `Send` could land between the `maxPacketLen`-sized fragments that a concurrent `WriteBytes(>16KB)` emits under the `packetLock` write lock. The peer then decoded `pkg1[:16384] + pkg2 + pkg1[16384:]`, lost framing, and either split the session or handed mis-framed bytes to the business layer.
2. **Write-timeout pollution.** `WritePkg(pkg, timeout>0)` temporarily rewrites the connection-level write timeout while holding `packetLock.Lock()` (save/restore via `defer`). A `Send` that ignores `packetLock` could run inside that window.

**Fix:** `Send` now takes `packetLock.RLock()` around the write. A read lock is sufficient because `Send` performs exactly one `conn.Send`, so it only needs to be mutually exclusive with the fragmenting (write-locked) writer — the same reasoning as the existing `WriteBytes(<=16KB)` path.

## #112 — session lock scope

The recursive-RLock deadlock described in #112 is removed by the same change: `s.lock` is snapshotted and released *before* `conn.Send`, so `gettyUDPConn.Send` -> `EndPoint()` no longer re-enters a lock the caller still holds.

Three further items from #112 are still live on master and are fixed here:

- **`WriteTimeout()`** was the promoted `Connection` method with no nil guard, so `stop()` segfaulted once `gc()`/`Reset()` had cleared `s.Connection`. It now mirrors `ReadTimeout()` and the other guarded promoted methods.
- **`gc()`** passed a `time.Duration` to `CloseConn(waitSec int)`. `int(3s)` is `3000000000`, which overflows the int32 linger field, so `Close()` blocked for minutes instead of the pending duration. Now converted to seconds.
- **`Conn()` / `gettyConn()`** read `s.Connection` without `s.lock` while `gc()`/`Reset()` write it — flagged by the race detector. Both now snapshot under `s.lock` and unwrap via `netConnOf` / `gettyConnOf`; `WritePkg` uses `gettyConnOf` with the snapshot it already holds, so the new locking cannot recurse.

(The fourth item in #112, `CloseConn` nil-ing `t.conn` while `WriteBytes` runs, was already fixed upstream by the `closeOnce` / `closing` rework.)

## Tests

All deterministic — no sleeps or timing luck, except the race test which relies on the race detector (CI runs `make test-race`).

| Test | Covers |
|---|---|
| `TestSendWaitsForWriteBytesFragments` | #131: gated `net.Conn` freezes the first fragment; asserts `Send` waits and the wire order is `[16384, 1, 6]` |
| `TestSendDoesNotHoldSessionLockAcrossConnectionSend` | #112: stub `Connection` reports via `TryLock` whether `s.lock` was held across the call, then calls `EndPoint()` |
| `TestGCClosesConnWithSeconds` | #112: `CloseConn` receives `3`, not `3000000000` |
| `TestWriteTimeoutIsNilSafeAfterReset` | #112: `WriteTimeout()` returns 0 after `Reset()` instead of panicking |
| `TestStatAndConnAreSafeDuringGC` | #112: `Stat()`/`Conn()` racing `gc()` under `-race` |

Each was verified to fail on `upstream/master`:

- no fix: `Send wrote 6 bytes while a WriteBytes fragment was in flight`
- no fix: `session.Send held s.lock across Connection.Send`
- no fix: `CloseConn waitSec = 3000000000, want 3`
- no fix: `panic: runtime error: invalid memory address or nil pointer dereference` in `WriteTimeout()`
- no fix: `WARNING: DATA RACE` on `session.go` `Conn()`/`gettyConn()` vs `gc()`

`go test ./...` and `go test -race ./transport` both pass with the fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session write handling so direct sends remain ordered with other outgoing data.
  * Prevented concurrent writes from interleaving packet fragments, improving transmission reliability.
  * Fixed connection cleanup timing to prevent extended linger periods.
  * Prevented errors when checking write timeouts after a session reset.
  * Improved reliability when session status and connection details are accessed during cleanup.
  * Improved connection handling during concurrent sends and cleanup operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->