### PR TITLE
fix: close the run/stop lifecycle races in session

### DIFF
--- a/transport/session.go
+++ b/transport/session.go
@@ -347,10 +347,16 @@ func (s *session) Stat() string {
 // IsClosed check whether the session has been closed.
 func (s *session) IsClosed() bool {
 	s.lock.RLock()
-	done := s.done
-	s.lock.RUnlock()
+	defer s.lock.RUnlock()
+	return s.closedLocked()
+}
+
+// closedLocked reports whether s.done has been closed. The caller must hold
+// s.lock; run() uses it to test-and-install the heartbeat timer atomically
+// against stopHeartbeat().
+func (s *session) closedLocked() bool {
 	select {
-	case <-done:
+	case <-s.done:
 		return true
 
 	default:
@@ -732,15 +738,28 @@ func (s *session) run() {
 	}
 
 	s.lock.Lock()
+	// #129: OnOpen may have closed the session (directly, or from a goroutine it
+	// handed the session to), in which case stop() already ran stopHeartbeat()
+	// while heartbeatTimer was still nil. A TimerLoop installed afterwards can
+	// never be stopped — stop()'s repeat callers do not re-run the once body —
+	// so the wheel would keep a heartbeatContext (and the whole session) alive
+	// forever. Testing s.done under the same lock stopHeartbeat() takes makes
+	// the test and the install atomic with respect to stop().
 	lifecycle := s.lifecycle
-	timer, err := defaultTimerWheel.AddTimer(
-		heartbeat,
-		gxtime.TimerLoop,
-		s.period,
-		&heartbeatContext{session: s, lifecycle: lifecycle},
+	var (
+		timer *gxtime.Timer
+		err   error
 	)
-	if err == nil {
-		s.heartbeatTimer = timer
+	if !s.closedLocked() {
+		timer, err = defaultTimerWheel.AddTimer(
+			heartbeat,
+			gxtime.TimerLoop,
+			s.period,
+			&heartbeatContext{session: s, lifecycle: lifecycle},
+		)
+		if err == nil {
+			s.heartbeatTimer = timer
+		}
 	}
 	s.lock.Unlock()
 	if err != nil {
@@ -1045,57 +1064,57 @@ func (s *session) handleWSPackage() error {
 }
 
 func (s *session) stop() {
-	select {
-	case <-s.done: // s.done is a blocked channel. if it has not been closed, the default branch will be invoked.
-		return
-
-	default:
-		s.once.Do(func() {
-			// let read/Write timeout asap
-			now := time.Now()
-			if conn := s.Conn(); conn != nil {
-				if err := conn.SetReadDeadline(now.Add(s.ReadTimeout())); err != nil {
-					log.Warnf("failed to set read deadline: %+v", err)
-				}
-				if err := conn.SetWriteDeadline(now.Add(s.WriteTimeout())); err != nil {
-					log.Warnf("failed to set write deadline: %+v", err)
-				}
+	// #129: a repeat stop() used to return as soon as s.done was closed, while
+	// the first caller was still inside the once body. handlePackage's
+	// `s.stop(); s.gc()` defer could then run gc() — which clears s.attrs —
+	// before the body read sessionClientKey/ignoreReconnectKey, silently
+	// dropping the reconnect. Always going through once.Do makes repeat callers
+	// wait for the body, so the attributes are still readable when it finishes.
+	s.once.Do(func() {
+		// let read/Write timeout asap
+		now := time.Now()
+		if conn := s.Conn(); conn != nil {
+			if err := conn.SetReadDeadline(now.Add(s.ReadTimeout())); err != nil {
+				log.Warnf("failed to set read deadline: %+v", err)
 			}
-			close(s.done)
-			lifecycle := s.stopHeartbeat()
+			if err := conn.SetWriteDeadline(now.Add(s.WriteTimeout())); err != nil {
+				log.Warnf("failed to set write deadline: %+v", err)
+			}
+		}
+		close(s.done)
+		lifecycle := s.stopHeartbeat()
 
-			s.closeCallbackMutex.RLock()
-			closeCallbacks := s.closeCallback
-			s.closeCallbackMutex.RUnlock()
+		s.closeCallbackMutex.RLock()
+		closeCallbacks := s.closeCallback
+		s.closeCallbackMutex.RUnlock()
+		if lifecycle != nil {
+			lifecycle.addClosingTask()
+		}
+
+		go func(sessionToken string, closeCallbacks callbacks, lifecycle *sessionLifecycle) {
 			if lifecycle != nil {
-				lifecycle.addClosingTask()
+				defer lifecycle.release()
 			}
-
-			go func(sessionToken string, closeCallbacks callbacks, lifecycle *sessionLifecycle) {
-				if lifecycle != nil {
-					defer lifecycle.release()
+			defer func() {
+				if r := recover(); r != nil {
+					const size = 64 << 10
+					rBuf := make([]byte, size)
+					rBuf = rBuf[:runtime.Stack(rBuf, false)]
+					err := perrors.WithStack(fmt.Errorf("[session.invokeCloseCallbacks] panic session %s: err=%v\n%s",
+						sessionToken, r, rBuf))
+					log.Error(err)
 				}
-				defer func() {
-					if r := recover(); r != nil {
-						const size = 64 << 10
-						rBuf := make([]byte, size)
-						rBuf = rBuf[:runtime.Stack(rBuf, false)]
-						err := perrors.WithStack(fmt.Errorf("[session.invokeCloseCallbacks] panic session %s: err=%v\n%s",
-							sessionToken, r, rBuf))
-						log.Error(err)
-					}
-				}()
+			}()
 
-				closeCallbacks.Invoke()
-			}(s.sessionToken(), closeCallbacks, lifecycle)
+			closeCallbacks.Invoke()
+		}(s.sessionToken(), closeCallbacks, lifecycle)
 
-			clt, cltFound := s.GetAttribute(sessionClientKey).(*client)
-			ignoreReconnect, flagFound := s.GetAttribute(ignoreReconnectKey).(bool)
-			if cltFound && flagFound && !ignoreReconnect {
-				clt.runReconnect()
-			}
-		})
-	}
+		clt, cltFound := s.GetAttribute(sessionClientKey).(*client)
+		ignoreReconnect, flagFound := s.GetAttribute(ignoreReconnectKey).(bool)
+		if cltFound && flagFound && !ignoreReconnect {
+			clt.runReconnect()
+		}
+	})
 }
 
 func (s *session) stopHeartbeat() *sessionLifecycle {

--- a/transport/session_test.go
+++ b/transport/session_test.go
@@ -520,3 +520,85 @@ func TestSetMethodsAfterGCDoNotPanic(t *testing.T) {
 	ss.SetCompressType(CompressZip)
 	ss.CloseConn(0)
 }
+
+// closeOnOpenListener closes the session from OnOpen and still reports success,
+// the pattern that used to leave run() installing a heartbeat timer on an
+// already closed session (#129).
+type closeOnOpenListener struct{}
+
+func (*closeOnOpenListener) OnOpen(ss Session) error { ss.Close(); return nil }
+func (*closeOnOpenListener) OnClose(Session)         {}
+func (*closeOnOpenListener) OnError(Session, error)  {}
+func (*closeOnOpenListener) OnCron(Session)          {}
+func (*closeOnOpenListener) OnMessage(Session, any)  {}
+
+// Regression test for #129: OnOpen closed the session, so stop() ran
+// stopHeartbeat() while heartbeatTimer was nil. run() then installed a
+// TimerLoop that no later stop() could remove, pinning the session in the
+// global timer wheel forever.
+func TestRunDoesNotInstallHeartbeatAfterClose(t *testing.T) {
+	ss := newTCPSession(&eofDataNetConn{}, newServer(TCP_SERVER)).(*session)
+	ss.SetReader(wholeFrameReader{})
+	ss.SetWriter(timeoutTestWriter{})
+	ss.SetEventListener(&closeOnOpenListener{})
+
+	ss.run()
+	ss.grWG.Wait()
+
+	ss.lock.RLock()
+	timer := ss.heartbeatTimer
+	ss.lock.RUnlock()
+	if timer != nil {
+		t.Fatal("run() installed a heartbeat timer on an already closed session; nothing can stop it")
+	}
+}
+
+// Regression test for #129: a repeat stop() used to return as soon as s.done
+// was closed, so handlePackage's `s.stop(); s.gc()` defer could clear s.attrs
+// while the first stop() was still inside its once body, dropping the
+// reconnect. The parked body below is where that lookup happens.
+func TestRepeatStopWaitsForCloseSequence(t *testing.T) {
+	ss := newTCPSession(&eofDataNetConn{}, newServer(TCP_SERVER)).(*session)
+
+	ss.closeCallbackMutex.Lock()
+
+	firstDone := make(chan struct{})
+	go func() {
+		ss.stop()
+		close(firstDone)
+	}()
+
+	select {
+	case <-ss.done:
+	case <-time.After(time.Second):
+		ss.closeCallbackMutex.Unlock()
+		t.Fatal("first stop() did not close the session")
+	}
+
+	secondDone := make(chan struct{})
+	go func() {
+		ss.stop()
+		close(secondDone)
+	}()
+
+	select {
+	case <-secondDone:
+		ss.closeCallbackMutex.Unlock()
+		<-firstDone
+		t.Fatal("repeat stop() returned while the close sequence was still running")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	ss.closeCallbackMutex.Unlock()
+
+	select {
+	case <-secondDone:
+	case <-time.After(time.Second):
+		t.Fatal("repeat stop() did not return after the close sequence completed")
+	}
+	select {
+	case <-firstDone:
+	case <-time.After(time.Second):
+		t.Fatal("first stop() did not return")
+	}
+}


### PR DESCRIPTION
Fixes #129.

Both races are in `session`'s run/stop lifecycle.

## 1. `run()` installed a heartbeat timer on an already closed session

`OnOpen` may close the session — directly, or from a goroutine it handed the session to — and still return `nil`. `stop()` had then already run `stopHeartbeat()`, at a moment when `heartbeatTimer` was still `nil`. `run()` then unconditionally installed a `TimerLoop`:

```
stop()  -> stopHeartbeat()  (heartbeatTimer == nil, nothing to stop)
run()   -> AddTimer(...)    -> s.heartbeatTimer = timer   <-- leaked
```

No later `stop()` can remove it, because a repeat `stop()` does not re-run the `once` body. The wheel then keeps a `heartbeatContext` — and through it the whole `*session` with its `Connection` and listener — alive forever, and the heartbeat spins once per period until the process exits.

**Fix:** the test-and-install happens under the same `s.lock` that `stopHeartbeat()` takes, so it is atomic with respect to `stop()`. The closed check is shared with `IsClosed()` through a new `closedLocked()`.

```go
if !s.closedLocked() {
        timer, err = defaultTimerWheel.AddTimer(...)
        ...
}
```

The read goroutine is still started, so `handlePackage`'s `stop(); gc()` defer still closes the connection.

## 2. `stop()`'s fast path bypassed the `once` barrier

```go
select {
case <-s.done:
        return          // second caller returns while the first is still in the body
default:
        s.once.Do(func() { ... })
}
```

Sequence: goroutine A enters the body, `close(s.done)`s, and is preempted before reading the reconnect attributes. The read goroutine notices `IsClosed`, exits, and its defer runs `s.stop()` — which hit the fast path and returned — followed by `s.gc()`, which sets `s.attrs = nil`. When A resumes, `GetAttribute(sessionClientKey)` returns `nil`, `cltFound` is false, and `clt.runReconnect()` is skipped. The client pool silently loses a connection and never refills it.

**Fix:** `stop()` always goes through `once.Do`, so repeat callers wait for the body. Reading the attributes outside the lock, before `close(s.done)`, was the alternative, but it would have widened the window in which a user `Close()` racing the EOF path observes a stale `ignoreReconnect`.

> Most of the `stop()` diff is the `once` body losing one level of indentation; `git diff -w` shows the semantic change is only the removed fast path.

## Tests

Both are deterministic and both fail on master:

- `TestRunDoesNotInstallHeartbeatAfterClose` — a listener closes the session from `OnOpen` and returns `nil`; the test then asserts `run()` left no heartbeat timer behind. On master: `run() installed a heartbeat timer on an already closed session; nothing can stop it`.
- `TestRepeatStopWaitsForCloseSequence` — parks the first `stop()` inside its `once` body by holding `closeCallbackMutex`, then asserts a repeat `stop()` does not return early. On master: `repeat stop() returned while the close sequence was still running`.

`go test ./...` and `go test -race ./transport` both pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session shutdown handling to prevent race conditions during closure.
  * Prevented heartbeat timers from being installed after a session has closed.
  * Ensured repeated shutdown requests wait for the initial close sequence to complete.
* **Tests**
  * Added regression coverage for session closure and heartbeat behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->