### PR TITLE
test: add benchmarks under benchmark/ (go test -bench suite + external load-test server)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,12 +21,14 @@ MAKEFLAGS += --warn-undefined-variables
 MAKEFLAGS += --no-builtin-rules
 MAKEFLAGS += --no-print-directory
 
-.PHONY: help test test-race fmt check-fmt clean lint install-golangci-lint install-imports-formatter
+.PHONY: help test test-race bench bench-echo fmt check-fmt clean lint install-golangci-lint install-imports-formatter
 
 help:
 	@echo "Available commands:"
 	@echo "  test       - Run unit tests with coverage"
 	@echo "  test-race  - Run transport race tests"
+	@echo "  bench      - Run the full benchmark suite (loopback TCP/WS/UDP)"
+	@echo "  bench-echo - Run only the client/server echo benchmarks"
 	@echo "  fmt        - Format code"
 	@echo "  check-fmt  - Verify formatting without modifying tracked files"
 	@echo "  lint       - Run golangci-lint"
@@ -38,6 +40,17 @@ test: clean
 
 test-race:
 	GOTOOLCHAIN=go1.25.0+auto go test -race ./transport -count=1
+
+# Benchmarks live in ./benchmark and are deliberately not part of the CI gate:
+# they talk to a real loopback socket, so their absolute numbers move with the
+# machine. Compare runs with benchstat, e.g.
+#   make bench > old.txt && git switch my-change && make bench > new.txt
+#   benchstat old.txt new.txt
+bench:
+	GOTOOLCHAIN=go1.25.0+auto go test -run '^$$' -bench . -benchmem -benchtime=1s ./benchmark
+
+bench-echo:
+	GOTOOLCHAIN=go1.25.0+auto go test -run '^$$' -bench 'BenchmarkEcho' -benchmem -benchtime=1s ./benchmark
 
 fmt: install-imports-formatter
 	go fmt ./... && GOROOT=$(shell go env GOROOT) imports-formatter

--- a/Makefile
+++ b/Makefile
@@ -21,14 +21,16 @@ MAKEFLAGS += --warn-undefined-variables
 MAKEFLAGS += --no-builtin-rules
 MAKEFLAGS += --no-print-directory
 
-.PHONY: help test test-race bench bench-echo fmt check-fmt clean lint install-golangci-lint install-imports-formatter
+.PHONY: help test test-race bench bench-echo bench-stable bench-server fmt check-fmt clean lint install-golangci-lint install-imports-formatter
 
 help:
 	@echo "Available commands:"
 	@echo "  test       - Run unit tests with coverage"
 	@echo "  test-race  - Run transport race tests"
-	@echo "  bench      - Run the full benchmark suite (loopback TCP/WS/UDP)"
-	@echo "  bench-echo - Run only the client/server echo benchmarks"
+	@echo "  bench        - Run the full benchmark suite (loopback TCP/WS/UDP)"
+	@echo "  bench-echo   - Run only the client/server echo benchmarks"
+	@echo "  bench-stable - bench with -count=5, for numbers worth quoting"
+	@echo "  bench-server - Run the standalone getty server for an external load generator"
 	@echo "  fmt        - Format code"
 	@echo "  check-fmt  - Verify formatting without modifying tracked files"
 	@echo "  lint       - Run golangci-lint"
@@ -51,6 +53,18 @@ bench:
 
 bench-echo:
 	GOTOOLCHAIN=go1.25.0+auto go test -run '^$$' -bench 'BenchmarkEcho' -benchmem -benchtime=1s ./benchmark
+
+# One run of a socket benchmark is noisy: a few percent difference means nothing
+# until it survives repetition. Use this when a number is going to be quoted, and
+# compare runs with benchstat.
+bench-stable:
+	GOTOOLCHAIN=go1.25.0+auto go test -run '^$$' -bench . -benchmem -benchtime=1s -count=5 ./benchmark
+
+# The other half of the picture: a standalone process to drive with an external
+# generator (tcpkali, see benchmark/doc.go), so the load client shares neither
+# this server's scheduler nor its heap.
+bench-server:
+	GOTOOLCHAIN=go1.25.0+auto go run ./benchmark/server -addr 127.0.0.1:12345 -mode echo
 
 fmt: install-imports-formatter
 	go fmt ./... && GOROOT=$(shell go env GOROOT) imports-formatter

--- a/benchmark/doc.go
+++ b/benchmark/doc.go
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package benchmark holds getty's benchmarks. They are deliberately a separate
+// package so they exercise nothing but the public API, exactly like a user of
+// the library would, and so the library's own unit tests stay free of
+// measurement code.
+//
+// Run them with `make bench` (all) or `make bench-echo` (loopback client/server
+// echo only).
+package benchmark

--- a/benchmark/doc.go
+++ b/benchmark/doc.go
@@ -15,11 +15,52 @@
  * limitations under the License.
  */
 
-// Package benchmark holds getty's benchmarks. They are deliberately a separate
-// package so they exercise nothing but the public API, exactly like a user of
-// the library would, and so the library's own unit tests stay free of
-// measurement code.
+// Package benchmark holds getty's benchmarks. They are a separate package on
+// purpose: they exercise nothing but the public API, exactly like a user of the
+// library, and the library's own unit tests stay free of measurement code.
 //
-// Run them with `make bench` (all) or `make bench-echo` (loopback client/server
-// echo only).
+// There are two kinds of measurement here, answering two different questions.
+//
+// # What does a code path cost
+//
+// The *_test.go files are ordinary Go benchmarks. Each case runs in this process
+// against a loopback socket and reports ns/op, MB/s, allocs/op and the p50, p99
+// and p999 latency of one operation, which is what you compare against the same
+// benchmark on another revision:
+//
+//	make bench          # every case, -benchtime=1s
+//	make bench-echo     # only the client/server echo cases
+//	make bench-stable   # same as bench with -count=5, for numbers you quote
+//
+// Every case touches a real socket, so one run is noisy - a difference under a
+// few percent means nothing until it survives repetition. Compare runs with
+// benchstat rather than by eye:
+//
+//	make bench-stable > old.txt
+//	git switch my-change
+//	make bench-stable > new.txt
+//	benchstat old.txt new.txt
+//
+// # How much traffic can getty serve
+//
+// ./server is a standalone getty process, meant to be driven by an external load
+// generator so that the client shares neither the server's scheduler nor its
+// heap. tcpkali is the generator the sibling apache/dubbo-getty benchmark uses:
+//
+//	make bench-server                 # terminal 1
+//	tcpkali --workers 4 -c 100 -T 30s -e -m "PING\n" 127.0.0.1:12345   # terminal 2
+//
+// -mode sink consumes without framing and reports receive throughput; -mode echo
+// frames on '\n' and writes each message back. tcpkali can also report latency
+// percentiles for the echo mode, since the echoed message is a usable marker:
+//
+//	tcpkali --workers 4 -c 10 -T 30s -e -m "PING\n" --latency-marker PING \
+//		--latency-percentiles 50,99,99.9 127.0.0.1:12345
+//
+// Run ./server -h for the rest of the flags (compression, log level, message
+// size limit).
+//
+// Neither kind of measurement is part of the CI gate: their absolute numbers
+// move with the machine, and a benchmark that fails on a slow runner teaches
+// nothing.
 package benchmark

--- a/benchmark/echo_test.go
+++ b/benchmark/echo_test.go
@@ -173,14 +173,30 @@ func BenchmarkEchoUDP(b *testing.B) {
 			b.ReportAllocs()
 			b.StartTimer()
 
+			// udp may lose a datagram, so a missing reply is a bounded retry, not
+			// a 30 second wait: the loss is counted and reported instead of
+			// turning the whole suite red.
 			ctx := getty.UDPContext{Pkg: payload}
+			var lost int64
 			for i := 0; i < b.N; i++ {
 				start := time.Now()
 				if _, _, err := ss.WritePkg(ctx, 0); err != nil {
 					b.Fatal(err)
 				}
-				e.waitReply(b)
+				for attempt := 1; !e.waitReplyWithin(udpReplyTimeout); attempt++ {
+					lost++
+					if attempt > udpMaxRetries {
+						b.Fatalf("udp echo lost %d consecutive replies (server received %d datagrams, client received %d)",
+							attempt, e.serverRecv.Load(), e.clientRecv.Load())
+					}
+					if _, _, err := ss.WritePkg(ctx, 0); err != nil {
+						b.Fatal(err)
+					}
+				}
 				latency.record(time.Since(start))
+			}
+			if lost > 0 {
+				b.ReportMetric(float64(lost), "lost")
 			}
 			latency.report(b)
 		})

--- a/benchmark/echo_test.go
+++ b/benchmark/echo_test.go
@@ -20,6 +20,7 @@ package benchmark
 import (
 	"fmt"
 	"testing"
+	"time"
 )
 
 import (
@@ -43,16 +44,20 @@ func BenchmarkEchoPingPong(b *testing.B) {
 				e := newBenchEcho(b, transport, lengthPrefixedCodec{}, getty.CompressNone, 1)
 				ss := e.sessions[0]
 				payload := benchPayload(size)
+				latency := newLatencyRecorder(b.N)
 				b.SetBytes(int64(size))
 				b.ReportAllocs()
 				b.StartTimer()
 
 				for i := 0; i < b.N; i++ {
+					start := time.Now()
 					if _, _, err := ss.WritePkg(payload, 0); err != nil {
 						b.Fatal(err)
 					}
 					e.waitReply(b)
+					latency.record(time.Since(start))
 				}
+				latency.report(b)
 			})
 		}
 	}
@@ -150,6 +155,35 @@ func BenchmarkEchoCompression(b *testing.B) {
 				}
 			})
 		}
+	}
+}
+
+// BenchmarkEchoUDP is the datagram round trip: one connected udp client against
+// a packet endpoint that writes each datagram back. Sizes stay under the
+// smallest common datagram limit (macOS caps one at 9216 bytes by default).
+func BenchmarkEchoUDP(b *testing.B) {
+	for _, size := range []int{64, 1 << 10, 4 << 10} {
+		b.Run(sizeName(size), func(b *testing.B) {
+			b.StopTimer()
+			e := newBenchEcho(b, "udp", udpEchoCodec{}, getty.CompressNone, 1)
+			ss := e.sessions[0]
+			payload := benchPayload(size)
+			latency := newLatencyRecorder(b.N)
+			b.SetBytes(int64(size))
+			b.ReportAllocs()
+			b.StartTimer()
+
+			ctx := getty.UDPContext{Pkg: payload}
+			for i := 0; i < b.N; i++ {
+				start := time.Now()
+				if _, _, err := ss.WritePkg(ctx, 0); err != nil {
+					b.Fatal(err)
+				}
+				e.waitReply(b)
+				latency.record(time.Since(start))
+			}
+			latency.report(b)
+		})
 	}
 }
 

--- a/benchmark/echo_test.go
+++ b/benchmark/echo_test.go
@@ -1,0 +1,177 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package benchmark
+
+import (
+	"fmt"
+	"testing"
+)
+
+import (
+	getty "github.com/AlexStocks/getty/transport"
+)
+
+// These benchmarks run a real getty client/server echo pair over loopback, so a
+// single ns/op mixes getty with the kernel and the scheduler. Use them to
+// compare configurations and revisions measured in the same run, never as an
+// absolute throughput number.
+//
+// Starting the pair is expensive, so every case stops the timer for setup and
+// restarts it with b.StartTimer() before the measured loop.
+// BenchmarkEchoPingPong is one request in flight at a time: ns/op is the full
+// round trip (client codec -> conn -> server codec -> echo -> client codec).
+func BenchmarkEchoPingPong(b *testing.B) {
+	for _, transport := range []string{"tcp", "ws"} {
+		for _, size := range echoSizes(transport) {
+			b.Run(transport+"/"+sizeName(size), func(b *testing.B) {
+				b.StopTimer()
+				e := newBenchEcho(b, transport, lengthPrefixedCodec{}, getty.CompressNone, 1)
+				ss := e.sessions[0]
+				payload := benchPayload(size)
+				b.SetBytes(int64(size))
+				b.ReportAllocs()
+				b.StartTimer()
+
+				for i := 0; i < b.N; i++ {
+					if _, _, err := ss.WritePkg(payload, 0); err != nil {
+						b.Fatal(err)
+					}
+					e.waitReply(b)
+				}
+			})
+		}
+	}
+}
+
+// BenchmarkEchoPipeline keeps `inflight` requests in flight, which is what a
+// real client does; MB/s becomes meaningful as the round trip stops being the
+// limit.
+func BenchmarkEchoPipeline(b *testing.B) {
+	for _, inflight := range []int{1, 8, 64} {
+		for _, size := range []int{1 << 10, 16 << 10, 64 << 10} {
+			b.Run(fmt.Sprintf("inflight=%d/%s", inflight, sizeName(size)), func(b *testing.B) {
+				b.StopTimer()
+				e := newBenchEcho(b, "tcp", lengthPrefixedCodec{}, getty.CompressNone, 1)
+				ss := e.sessions[0]
+				payload := benchPayload(size)
+				b.SetBytes(int64(size))
+				b.ReportAllocs()
+				b.StartTimer()
+
+				sent, recv := 0, 0
+				for recv < b.N {
+					for sent < b.N && sent-recv < inflight {
+						if _, _, err := ss.WritePkg(payload, 0); err != nil {
+							b.Fatal(err)
+						}
+						sent++
+					}
+					e.waitReply(b)
+					recv++
+				}
+			})
+		}
+	}
+}
+
+// BenchmarkEchoCodec compares the minimal binary framing with the same framing
+// plus an encoding/json pass, so the codec cost is visible next to the
+// framework cost.
+func BenchmarkEchoCodec(b *testing.B) {
+	for _, tc := range []struct {
+		name  string
+		codec getty.ReadWriter
+		pkg   func([]byte) any
+	}{
+		{"binary", lengthPrefixedCodec{}, func(p []byte) any { return p }},
+		{"json", jsonCodec{}, func(p []byte) any { return &jsonPkg{Body: p} }},
+	} {
+		for _, size := range []int{1 << 10, 16 << 10} {
+			b.Run(tc.name+"/"+sizeName(size), func(b *testing.B) {
+				b.StopTimer()
+				e := newBenchEcho(b, "tcp", tc.codec, getty.CompressNone, 1)
+				ss := e.sessions[0]
+				pkg := tc.pkg(benchPayload(size))
+				b.SetBytes(int64(size))
+				b.ReportAllocs()
+				b.StartTimer()
+
+				for i := 0; i < b.N; i++ {
+					if _, _, err := ss.WritePkg(pkg, 0); err != nil {
+						b.Fatal(err)
+					}
+					e.waitReply(b)
+				}
+			})
+		}
+	}
+}
+
+// BenchmarkEchoCompression runs the round trip through the connection codec.
+func BenchmarkEchoCompression(b *testing.B) {
+	for _, tc := range []struct {
+		name     string
+		compress getty.CompressType
+	}{
+		{"raw", getty.CompressNone},
+		{"zip", getty.CompressZip},
+		{"snappy", getty.CompressSnappy},
+	} {
+		for _, size := range []int{1 << 10, 16 << 10} {
+			b.Run(tc.name+"/"+sizeName(size), func(b *testing.B) {
+				b.StopTimer()
+				e := newBenchEcho(b, "tcp", lengthPrefixedCodec{}, tc.compress, 1)
+				ss := e.sessions[0]
+				payload := benchPayload(size)
+				b.SetBytes(int64(size))
+				b.ReportAllocs()
+				b.StartTimer()
+
+				for i := 0; i < b.N; i++ {
+					if _, _, err := ss.WritePkg(payload, 0); err != nil {
+						b.Fatal(err)
+					}
+					e.waitReply(b)
+				}
+			})
+		}
+	}
+}
+
+// BenchmarkEchoConnections spreads one request at a time over a pool of conns
+// sessions, exposing the per-connection fixed cost of the pool.
+func BenchmarkEchoConnections(b *testing.B) {
+	const size = 1 << 10
+	for _, conns := range []int{1, 8, 64} {
+		b.Run(fmt.Sprintf("conns=%d", conns), func(b *testing.B) {
+			b.StopTimer()
+			e := newBenchEcho(b, "tcp", lengthPrefixedCodec{}, getty.CompressNone, conns)
+			payload := benchPayload(size)
+			b.SetBytes(int64(size))
+			b.ReportAllocs()
+			b.StartTimer()
+
+			for i := 0; i < b.N; i++ {
+				if _, _, err := e.sessions[i%conns].WritePkg(payload, 0); err != nil {
+					b.Fatal(err)
+				}
+				e.waitReply(b)
+			}
+		})
+	}
+}

--- a/benchmark/helper_test.go
+++ b/benchmark/helper_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"os"
 	"runtime"
 	"sort"
 	"strconv"
@@ -563,11 +564,17 @@ func (e *benchEcho) warmUpUDP(b *testing.B) {
 			return
 		}
 	}
-	b.Skipf("udp echo round trip could not be established in %d attempts: the server received %d datagrams, the client received %d. "+
+	reason := fmt.Sprintf("udp echo round trip could not be established in %d attempts: the server received %d datagrams, the client received %d. "+
 		"The udp endpoint round trip needs a look before this case can be measured; skipping it rather than failing every other case. "+
-		"Report this line with the environment below: %s/%s go%s",
+		"Environment: %s/%s go%s",
 		udpWarmupAttempts, e.serverRecv.Load(), e.clientRecv.Load(),
 		runtime.GOOS, runtime.GOARCH, strings.TrimPrefix(runtime.Version(), "go"))
+	// testing buffers a skip's message and its "--- SKIP:" line and only prints
+	// them with -v, and none of the make targets pass -v - so a case that did
+	// not run would vanish from `make bench` output entirely. Write the reason
+	// to stderr as well, where it is always visible.
+	fmt.Fprintln(os.Stderr, "benchmark: skipping", b.Name()+":", reason)
+	b.Skip(reason)
 }
 
 func setHandler(ss getty.Session, codec getty.ReadWriter, listener getty.EventListener, compress getty.CompressType) {

--- a/benchmark/helper_test.go
+++ b/benchmark/helper_test.go
@@ -26,6 +26,7 @@ import (
 	"sort"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -51,6 +52,13 @@ const (
 	// replyTimeout turns "the peer never echoed" into a failure instead of a
 	// hang.
 	replyTimeout = 30 * time.Second
+	// udpReplyTimeout bounds one datagram round trip. udp may lose a datagram,
+	// so a udp benchmark retries instead of waiting out replyTimeout.
+	udpReplyTimeout = time.Second
+	// udpWarmupAttempts bounds the pre-measurement round trip.
+	udpWarmupAttempts = 5
+	// udpMaxRetries bounds the resends for one lost reply inside the loop.
+	udpMaxRetries = 3
 	// maxMsgLen must exceed every echoed payload: session.handleTCPPackage and
 	// handleWSPackage drop any pkg larger than maxMsgLen, whose default is 4KB,
 	// so a 16KB echo would silently never come back.
@@ -170,17 +178,21 @@ func (udpEchoCodec) Write(_ getty.Session, pkg any) ([]byte, error) {
 	return body, nil
 }
 
-// udpEchoListener writes each datagram back to whoever sent it.
-type udpEchoListener struct{}
+// udpEchoListener writes each datagram back to whoever sent it, and counts what
+// it saw.
+type udpEchoListener struct{ recv *atomic.Int64 }
 
 func (udpEchoListener) OnOpen(getty.Session) error   { return nil }
 func (udpEchoListener) OnClose(getty.Session)        {}
 func (udpEchoListener) OnError(getty.Session, error) {}
 func (udpEchoListener) OnCron(getty.Session)         {}
-func (udpEchoListener) OnMessage(ss getty.Session, pkg any) {
+func (l udpEchoListener) OnMessage(ss getty.Session, pkg any) {
 	ctx, ok := pkg.(getty.UDPContext)
 	if !ok {
 		return
+	}
+	if l.recv != nil {
+		l.recv.Add(1)
 	}
 	_, _, _ = ss.WritePkg(ctx, 0)
 }
@@ -265,13 +277,19 @@ func (echoListener) OnMessage(ss getty.Session, pkg any) {
 }
 
 // replyListener signals the benchmark goroutine once per echoed pkg.
-type replyListener struct{ replies chan<- struct{} }
+type replyListener struct {
+	replies chan<- struct{}
+	recv    *atomic.Int64
+}
 
 func (replyListener) OnOpen(getty.Session) error   { return nil }
 func (replyListener) OnClose(getty.Session)        {}
 func (replyListener) OnError(getty.Session, error) {}
 func (replyListener) OnCron(getty.Session)         {}
 func (l replyListener) OnMessage(getty.Session, any) {
+	if l.recv != nil {
+		l.recv.Add(1)
+	}
 	l.replies <- struct{}{}
 }
 
@@ -372,12 +390,16 @@ func (l *latencyRecorder) record(d time.Duration) {
 	l.samples = append(l.samples, d)
 }
 
-// report publishes p50/p99/p999 as user metrics. It is a no-op when nothing was
-// recorded, so a benchmark that fails early does not report zeros.
+// report publishes p50/p99/p999 as user metrics. It stops the benchmark timer
+// first: the copy and the O(n log n) sort below would otherwise be charged to
+// ns/op, which would make two runs with different b.N incomparable. It is a
+// no-op when nothing was recorded, so a benchmark that fails early does not
+// report zeros.
 func (l *latencyRecorder) report(b *testing.B) {
 	if len(l.samples) == 0 {
 		return
 	}
+	b.StopTimer()
 	sorted := append([]time.Duration(nil), l.samples...)
 	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
 	percentile := func(p float64) float64 {
@@ -396,6 +418,10 @@ type benchEcho struct {
 	sessions   []getty.Session
 	replies    chan struct{}
 	replyTimer *time.Timer
+	// serverRecv and clientRecv exist so that a udp round trip that never
+	// completes can say *where* it broke instead of just timing out.
+	serverRecv *atomic.Int64
+	clientRecv *atomic.Int64
 }
 
 // newBenchEcho starts a server and a client pool of conns sessions, all sharing
@@ -407,6 +433,8 @@ func newBenchEcho(b *testing.B, transport string, codec getty.ReadWriter, compre
 	e := &benchEcho{
 		replies:    make(chan struct{}, replyBuffer),
 		replyTimer: time.NewTimer(replyTimeout),
+		serverRecv: &atomic.Int64{},
+		clientRecv: &atomic.Int64{},
 	}
 	// Registered before anything can fail, so a dial timeout or an unsupported
 	// transport still tears down whatever was already started instead of leaving
@@ -449,7 +477,7 @@ func newBenchEcho(b *testing.B, transport string, codec getty.ReadWriter, compre
 	// RunEventLoop blocks until the pool is dialled; run it in the background
 	// so a server that never accepts cannot pin the benchmark setup forever.
 	go e.cli.RunEventLoop(func(ss getty.Session) error {
-		setHandler(ss, codec, replyListener{replies: e.replies}, compress)
+		setHandler(ss, codec, replyListener{replies: e.replies, recv: e.clientRecv}, compress)
 		ready <- ss
 		return nil
 	})
@@ -485,7 +513,7 @@ func newBenchUDPEcho(b *testing.B, e *benchEcho, codec getty.ReadWriter) *benchE
 
 	e.srv = getty.NewUDPEndPoint(getty.WithLocalAddress("127.0.0.1:0"))
 	e.srv.RunEventLoop(func(ss getty.Session) error {
-		setHandler(ss, codec, udpEchoListener{}, getty.CompressNone)
+		setHandler(ss, codec, udpEchoListener{recv: e.serverRecv}, getty.CompressNone)
 		return nil
 	})
 	addr := e.srv.(getty.PacketServer).PacketConn().LocalAddr().String()
@@ -493,7 +521,7 @@ func newBenchUDPEcho(b *testing.B, e *benchEcho, codec getty.ReadWriter) *benchE
 	ready := make(chan getty.Session, 1)
 	e.cli = getty.NewUDPClient(getty.WithServerAddress(addr), getty.WithConnectionNumber(1))
 	go e.cli.RunEventLoop(func(ss getty.Session) error {
-		setHandler(ss, codec, replyListener{replies: e.replies}, getty.CompressNone)
+		setHandler(ss, codec, replyListener{replies: e.replies, recv: e.clientRecv}, getty.CompressNone)
 		ready <- ss
 		return nil
 	})
@@ -504,7 +532,31 @@ func newBenchUDPEcho(b *testing.B, e *benchEcho, codec getty.ReadWriter) *benchE
 	case <-time.After(dialTimeout):
 		b.Fatal("udp client session did not come up")
 	}
+
+	e.warmUpUDP(b)
 	return e
+}
+
+// A udp round trip is not guaranteed, and the client's own dial does a
+// write-then-read handshake with a one second deadline before the session even
+// exists (transport/client.go dialUDP), so the first datagrams of a benchmark
+// are the most likely to be dropped or eaten. Establishing one round trip
+// before measuring keeps the measured loop from timing out on a cold start, and
+// the counters below say exactly where it broke when it cannot.
+func (e *benchEcho) warmUpUDP(b *testing.B) {
+	b.Helper()
+	payload := benchPayload(16)
+	for attempt := 1; attempt <= udpWarmupAttempts; attempt++ {
+		if _, _, err := e.sessions[0].WritePkg(getty.UDPContext{Pkg: payload}, 0); err != nil {
+			b.Fatalf("udp warmup write: %v", err)
+		}
+		if e.waitReplyWithin(udpReplyTimeout) {
+			return
+		}
+	}
+	b.Skipf("udp echo round trip could not be established in %d attempts: the server received %d datagrams, the client received %d. "+
+		"The udp endpoint round trip needs a look before this case can be measured; skipping it rather than failing every other case.",
+		udpWarmupAttempts, e.serverRecv.Load(), e.clientRecv.Load())
 }
 
 func setHandler(ss getty.Session, codec getty.ReadWriter, listener getty.EventListener, compress getty.CompressType) {
@@ -526,18 +578,27 @@ func setHandler(ss getty.Session, codec getty.ReadWriter, listener getty.EventLi
 // its runtime timer churn into ns/op and allocs/op.
 func (e *benchEcho) waitReply(b *testing.B) {
 	b.Helper()
+	if !e.waitReplyWithin(replyTimeout) {
+		b.Fatalf("no echo came back within %s: the session dropped the pkg (maxMsgLen) or the peer died", replyTimeout)
+	}
+}
+
+// waitReplyWithin is waitReply with a caller-chosen bound, so a udp benchmark can
+// treat a missing datagram as a loss instead of a 30 second wall.
+func (e *benchEcho) waitReplyWithin(d time.Duration) bool {
 	if !e.replyTimer.Stop() {
 		select {
 		case <-e.replyTimer.C:
 		default:
 		}
 	}
-	e.replyTimer.Reset(replyTimeout)
+	e.replyTimer.Reset(d)
 
 	select {
 	case <-e.replies:
+		return true
 	case <-e.replyTimer.C:
-		b.Fatal("no echo came back: the session dropped the pkg (maxMsgLen) or the peer died")
+		return false
 	}
 }
 

--- a/benchmark/helper_test.go
+++ b/benchmark/helper_test.go
@@ -1,0 +1,443 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package benchmark
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+)
+
+import (
+	getty "github.com/AlexStocks/getty/transport"
+	gettylog "github.com/AlexStocks/getty/util"
+)
+
+const (
+	// maxPacketLen mirrors getty's unexported fragment size: WriteBytes above
+	// it switches from a single read-locked send to the write-locked
+	// fragmenting loop, so benchmarks cover both sides of that boundary.
+	maxPacketLen = 16 * 1024
+	// wsPath is the websocket endpoint both sides of the ws echo agree on.
+	wsPath = "/bench-echo"
+	// replyBuffer bounds the outstanding echo replies a client can have; keep
+	// every in-flight value well below it so the reply listener never blocks
+	// the session read loop.
+	replyBuffer = 4096
+	// dialTimeout bounds how long a benchmark waits for a client pool.
+	dialTimeout = 10 * time.Second
+	// replyTimeout turns "the peer never echoed" into a failure instead of a
+	// hang.
+	replyTimeout = 30 * time.Second
+	// maxMsgLen must exceed every echoed payload: session.handleTCPPackage and
+	// handleWSPackage drop any pkg larger than maxMsgLen, whose default is 4KB,
+	// so a 16KB echo would silently never come back.
+	maxMsgLen = 2 << 20
+)
+
+// sizes spans both sides of maxPacketLen.
+var sizes = []int{64, 1 << 10, maxPacketLen, maxPacketLen + 1, 64 << 10, 1 << 20}
+
+// Echo payload sizes per transport. ws stays under the 4KB default maxMsgLen: a
+// ws *client* has gorilla's read limit fixed from the default maxMsgLen while
+// the session is built, before NewSessionCallback can raise it, so a larger
+// echo is rejected with "read limit exceeded" no matter what the callback does.
+var (
+	tcpEchoSizes = []int{64, 1 << 10, maxPacketLen, 64 << 10}
+	wsEchoSizes  = []int{64, 1 << 10, 3 << 10}
+)
+
+func echoSizes(transport string) []int {
+	if transport == "ws" {
+		return wsEchoSizes
+	}
+	return tcpEchoSizes
+}
+
+// silenceLogs keeps getty's logging out of the numbers. gettyTCPConn.Send logs
+// on every call, and the libraries also log benign teardown events (a closed
+// http.Server), which would otherwise dominate the measurement and garble the
+// output. Failures surface through b.Fatal and the dial/reply timeouts instead.
+var silenceLogsOnce sync.Once
+
+func silenceLogs() {
+	silenceLogsOnce.Do(func() {
+		if err := gettylog.SetLoggerLevel(gettylog.LoggerLevelFatal); err != nil {
+			panic(err)
+		}
+		_ = gettylog.SetLoggerCallerDisable()
+	})
+}
+
+func benchPayload(n int) []byte {
+	p := make([]byte, n)
+	for i := range p {
+		p[i] = byte(i)
+	}
+	return p
+}
+
+// sizeName keeps the maxPacketLen boundary distinguishable from maxPacketLen+1.
+func sizeName(n int) string {
+	switch {
+	case n == maxPacketLen+1:
+		return "16K+1"
+	case n >= 1<<20:
+		return fmt.Sprintf("%dM", n>>20)
+	case n >= 1<<10:
+		return fmt.Sprintf("%dK", n>>10)
+	default:
+		return strconv.Itoa(n)
+	}
+}
+
+// nopCodec is the cheapest codec there is: Read never completes a pkg, so a
+// session using it only drains its peer, and Write passes a []byte straight
+// through. The write-path benchmarks use it so the codec is not part of what
+// they measure.
+type nopCodec struct{}
+
+func (nopCodec) Read(getty.Session, []byte) (any, int, error) { return nil, 0, nil }
+
+func (nopCodec) Write(_ getty.Session, pkg any) ([]byte, error) {
+	body, ok := pkg.([]byte)
+	if !ok {
+		return nil, fmt.Errorf("nopCodec: unexpected pkg type %T", pkg)
+	}
+	return body, nil
+}
+
+// udpCodec unwraps the UDPContext a udp session must be written with.
+type udpCodec struct{}
+
+func (udpCodec) Read(getty.Session, []byte) (any, int, error) { return nil, 0, nil }
+
+func (udpCodec) Write(_ getty.Session, pkg any) ([]byte, error) {
+	ctx, ok := pkg.(getty.UDPContext)
+	if !ok {
+		return nil, fmt.Errorf("udpCodec: unexpected pkg type %T", pkg)
+	}
+	body, ok := ctx.Pkg.([]byte)
+	if !ok {
+		return nil, fmt.Errorf("udpCodec: unexpected UDPContext.Pkg type %T", ctx.Pkg)
+	}
+	return body, nil
+}
+
+// lengthPrefixedCodec frames each pkg as a 4-byte big-endian length plus body.
+// It is the smallest codec a getty user would write, so the echo benchmarks
+// measure getty rather than a serialization library.
+type lengthPrefixedCodec struct{}
+
+func (lengthPrefixedCodec) Read(_ getty.Session, data []byte) (any, int, error) {
+	if len(data) < 4 {
+		return nil, 0, nil
+	}
+	n := int(binary.BigEndian.Uint32(data[:4]))
+	if n < 0 || len(data) < 4+n {
+		return nil, 0, nil
+	}
+	body := make([]byte, n)
+	copy(body, data[4:4+n])
+	return body, 4 + n, nil
+}
+
+func (lengthPrefixedCodec) Write(_ getty.Session, pkg any) ([]byte, error) {
+	body, ok := pkg.([]byte)
+	if !ok {
+		return nil, fmt.Errorf("lengthPrefixedCodec: unexpected pkg type %T", pkg)
+	}
+	frame := make([]byte, 4+len(body))
+	binary.BigEndian.PutUint32(frame[:4], uint32(len(body)))
+	copy(frame[4:], body)
+	return frame, nil
+}
+
+// jsonPkg is what the JSON codec benchmark round-trips.
+type jsonPkg struct {
+	Body []byte `json:"body"`
+}
+
+// jsonCodec keeps the same length framing and adds a JSON encode/decode inside
+// it.
+type jsonCodec struct{}
+
+func (jsonCodec) Read(ss getty.Session, data []byte) (any, int, error) {
+	body, n, err := lengthPrefixedCodec{}.Read(ss, data)
+	if body == nil || err != nil {
+		return nil, n, err
+	}
+	var pkg jsonPkg
+	if err := json.Unmarshal(body.([]byte), &pkg); err != nil {
+		return nil, 0, err
+	}
+	return &pkg, n, nil
+}
+
+func (jsonCodec) Write(_ getty.Session, pkg any) ([]byte, error) {
+	body, err := json.Marshal(pkg)
+	if err != nil {
+		return nil, err
+	}
+	return lengthPrefixedCodec{}.Write(nil, body)
+}
+
+// discardListener does nothing: the sessions that use it only send.
+type discardListener struct{}
+
+func (discardListener) OnOpen(getty.Session) error   { return nil }
+func (discardListener) OnClose(getty.Session)        {}
+func (discardListener) OnError(getty.Session, error) {}
+func (discardListener) OnCron(getty.Session)         {}
+func (discardListener) OnMessage(getty.Session, any) {}
+
+// echoListener writes every decoded pkg straight back, so a benchmark measures
+// the full write-codec-conn-read-codec round trip on both sides.
+type echoListener struct{}
+
+func (echoListener) OnOpen(getty.Session) error   { return nil }
+func (echoListener) OnClose(getty.Session)        {}
+func (echoListener) OnError(getty.Session, error) {}
+func (echoListener) OnCron(getty.Session)         {}
+func (echoListener) OnMessage(ss getty.Session, pkg any) {
+	_, _, _ = ss.WritePkg(pkg, 0)
+}
+
+// replyListener signals the benchmark goroutine once per echoed pkg.
+type replyListener struct{ replies chan<- struct{} }
+
+func (replyListener) OnOpen(getty.Session) error   { return nil }
+func (replyListener) OnClose(getty.Session)        {}
+func (replyListener) OnError(getty.Session, error) {}
+func (replyListener) OnCron(getty.Session)         {}
+func (l replyListener) OnMessage(getty.Session, any) {
+	l.replies <- struct{}{}
+}
+
+// drainListener is a raw TCP listener that throws away everything it receives.
+// It stands in for the peer in the write-path benchmarks: they measure a getty
+// client session writing to a socket, and the peer must neither apply
+// backpressure of its own nor add getty work to the measurement.
+func drainListener(tb testing.TB) (string, func()) {
+	tb.Helper()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		tb.Fatalf("net.Listen: %v", err)
+	}
+
+	var conns sync.Map
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			conns.Store(conn, struct{}{})
+			go func(c net.Conn) {
+				_, _ = io.Copy(io.Discard, c)
+			}(conn)
+		}
+	}()
+
+	return ln.Addr().String(), func() {
+		_ = ln.Close()
+		conns.Range(func(k, _ any) bool {
+			_ = k.(net.Conn).Close()
+			return true
+		})
+	}
+}
+
+// newWriteSession returns a getty TCP client session whose peer discards every
+// byte, so WriteBytes/WritePkg/Send can be measured against a real socket.
+// compress == getty.CompressNone leaves the connection raw: getty only installs
+// its flate/snappy codec when SetCompressType is called, and passing
+// CompressNone there would install flate at NoCompression level instead.
+func newWriteSession(b *testing.B, codec getty.ReadWriter, compress getty.CompressType) getty.Session {
+	b.Helper()
+	silenceLogs()
+
+	addr, closeDrain := drainListener(b)
+	ready := make(chan getty.Session, 1)
+	cli := getty.NewTCPClient(getty.WithServerAddress(addr), getty.WithConnectionNumber(1))
+	go cli.RunEventLoop(func(ss getty.Session) error {
+		ss.SetPkgHandler(codec)
+		ss.SetEventListener(discardListener{})
+		ss.SetReadTimeout(time.Minute)
+		ss.SetWriteTimeout(time.Minute)
+		if compress != getty.CompressNone {
+			// Must happen before any IO on the connection.
+			ss.SetCompressType(compress)
+		}
+		ready <- ss
+		return nil
+	})
+	b.Cleanup(func() {
+		cli.Close()
+		closeDrain()
+	})
+
+	select {
+	case ss := <-ready:
+		return ss
+	case <-time.After(dialTimeout):
+		b.Fatal("client session did not come up")
+		return nil
+	}
+}
+
+// benchEcho is a live getty client/server echo pair over loopback.
+type benchEcho struct {
+	srv        getty.StreamServer
+	cli        getty.Client
+	sessions   []getty.Session
+	replies    chan struct{}
+	replyTimer *time.Timer
+}
+
+// newBenchEcho starts a server and a client pool of conns sessions, all sharing
+// codec.
+func newBenchEcho(b *testing.B, transport string, codec getty.ReadWriter, compress getty.CompressType, conns int) *benchEcho {
+	b.Helper()
+	silenceLogs()
+
+	e := &benchEcho{
+		replies:    make(chan struct{}, replyBuffer),
+		replyTimer: time.NewTimer(replyTimeout),
+	}
+	// Registered before anything can fail, so a dial timeout or an unsupported
+	// transport still tears down whatever was already started instead of leaving
+	// a server and its event loop behind for the rest of the run.
+	b.Cleanup(e.close)
+
+	switch transport {
+	case "tcp":
+		e.srv = getty.NewTCPServer(getty.WithLocalAddress("127.0.0.1:0")).(getty.StreamServer)
+	case "ws":
+		e.srv = getty.NewWSServer(
+			getty.WithLocalAddress("127.0.0.1:0"),
+			getty.WithWebsocketServerPath(wsPath),
+		).(getty.StreamServer)
+	default:
+		b.Fatalf("unknown transport %q", transport)
+	}
+	e.srv.RunEventLoop(func(ss getty.Session) error {
+		setHandler(ss, codec, echoListener{}, compress)
+		return nil
+	})
+
+	addr := e.srv.Listener().Addr().String()
+	switch transport {
+	case "tcp":
+		e.cli = getty.NewTCPClient(getty.WithServerAddress(addr), getty.WithConnectionNumber(conns))
+	case "ws":
+		e.cli = getty.NewWSClient(
+			getty.WithServerAddress("ws://"+addr+wsPath),
+			getty.WithConnectionNumber(conns),
+		)
+	}
+	ready := make(chan getty.Session, conns)
+	// RunEventLoop blocks until the pool is dialled; run it in the background
+	// so a server that never accepts cannot pin the benchmark setup forever.
+	go e.cli.RunEventLoop(func(ss getty.Session) error {
+		setHandler(ss, codec, replyListener{replies: e.replies}, compress)
+		ready <- ss
+		return nil
+	})
+
+	timeout := time.After(dialTimeout)
+	for i := 0; i < conns; i++ {
+		select {
+		case ss := <-ready:
+			e.sessions = append(e.sessions, ss)
+		case <-timeout:
+			b.Fatalf("%s: only %d of %d client sessions came up", transport, i, conns)
+		}
+	}
+
+	// Drain anything sent during the handshake so the first measured iteration
+	// starts from an empty reply queue.
+	for drained := false; !drained; {
+		select {
+		case <-e.replies:
+		default:
+			drained = true
+		}
+	}
+
+	return e
+}
+
+func setHandler(ss getty.Session, codec getty.ReadWriter, listener getty.EventListener, compress getty.CompressType) {
+	ss.SetPkgHandler(codec)
+	ss.SetEventListener(listener)
+	ss.SetMaxMsgLen(maxMsgLen)
+	ss.SetReadTimeout(time.Minute)
+	ss.SetWriteTimeout(time.Minute)
+	if compress != getty.CompressNone {
+		ss.SetCompressType(compress)
+	}
+}
+
+// waitReply blocks until the peer echoed one pkg, and fails the benchmark
+// instead of hanging forever if it never does.
+//
+// It reuses one timer rather than calling time.After: waitReply runs inside the
+// measured loop, and a fresh timer per echoed pkg would put its allocation and
+// its runtime timer churn into ns/op and allocs/op.
+func (e *benchEcho) waitReply(b *testing.B) {
+	b.Helper()
+	if !e.replyTimer.Stop() {
+		select {
+		case <-e.replyTimer.C:
+		default:
+		}
+	}
+	e.replyTimer.Reset(replyTimeout)
+
+	select {
+	case <-e.replies:
+	case <-e.replyTimer.C:
+		b.Fatal("no echo came back: the session dropped the pkg (maxMsgLen) or the peer died")
+	}
+}
+
+// close is idempotent and tolerates a partially built pair, because it can run
+// after any early failure in newBenchEcho.
+func (e *benchEcho) close() {
+	if e.cli != nil {
+		e.cli.Close()
+	}
+	if e.srv != nil {
+		e.srv.Close()
+	}
+	// Give the session goroutines a chance to leave the timer wheel before the
+	// next benchmark builds its own pair.
+	for _, ss := range e.sessions {
+		if ss != nil {
+			ss.Close()
+		}
+	}
+}

--- a/benchmark/helper_test.go
+++ b/benchmark/helper_test.go
@@ -23,8 +23,10 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"runtime"
 	"sort"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -402,6 +404,13 @@ func (l *latencyRecorder) report(b *testing.B) {
 	b.StopTimer()
 	sorted := append([]time.Duration(nil), l.samples...)
 	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+	if sorted[len(sorted)-1] == 0 {
+		// Some platforms report a zero interval for a fast loop (coarse timer
+		// inside a VM, for instance). Publishing p50=0 would be worse than
+		// publishing nothing, so leave the percentiles out and say so.
+		b.ReportMetric(0, "p50-ns(clock-too-coarse)")
+		return
+	}
 	percentile := func(p float64) float64 {
 		idx := int(float64(len(sorted)-1) * p)
 		return float64(sorted[idx].Nanoseconds())
@@ -555,8 +564,10 @@ func (e *benchEcho) warmUpUDP(b *testing.B) {
 		}
 	}
 	b.Skipf("udp echo round trip could not be established in %d attempts: the server received %d datagrams, the client received %d. "+
-		"The udp endpoint round trip needs a look before this case can be measured; skipping it rather than failing every other case.",
-		udpWarmupAttempts, e.serverRecv.Load(), e.clientRecv.Load())
+		"The udp endpoint round trip needs a look before this case can be measured; skipping it rather than failing every other case. "+
+		"Report this line with the environment below: %s/%s go%s",
+		udpWarmupAttempts, e.serverRecv.Load(), e.clientRecv.Load(),
+		runtime.GOOS, runtime.GOARCH, strings.TrimPrefix(runtime.Version(), "go"))
 }
 
 func setHandler(ss getty.Session, codec getty.ReadWriter, listener getty.EventListener, compress getty.CompressType) {

--- a/benchmark/helper_test.go
+++ b/benchmark/helper_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"sort"
 	"strconv"
 	"sync"
 	"testing"
@@ -143,6 +144,45 @@ func (udpCodec) Write(_ getty.Session, pkg any) ([]byte, error) {
 		return nil, fmt.Errorf("udpCodec: unexpected UDPContext.Pkg type %T", ctx.Pkg)
 	}
 	return body, nil
+}
+
+// udpEchoCodec turns each datagram into one pkg, and unwraps the UDPContext a
+// udp session must be written with. handleUDPPackage hands OnMessage a
+// UDPContext{Pkg: <what Read returned>, PeerAddr: <sender>}, so echoing is just
+// writing that same context back.
+type udpEchoCodec struct{}
+
+func (udpEchoCodec) Read(_ getty.Session, data []byte) (any, int, error) {
+	body := make([]byte, len(data))
+	copy(body, data)
+	return body, len(data), nil
+}
+
+func (udpEchoCodec) Write(_ getty.Session, pkg any) ([]byte, error) {
+	ctx, ok := pkg.(getty.UDPContext)
+	if !ok {
+		return nil, fmt.Errorf("udpEchoCodec: unexpected pkg type %T", pkg)
+	}
+	body, ok := ctx.Pkg.([]byte)
+	if !ok {
+		return nil, fmt.Errorf("udpEchoCodec: unexpected UDPContext.Pkg type %T", ctx.Pkg)
+	}
+	return body, nil
+}
+
+// udpEchoListener writes each datagram back to whoever sent it.
+type udpEchoListener struct{}
+
+func (udpEchoListener) OnOpen(getty.Session) error   { return nil }
+func (udpEchoListener) OnClose(getty.Session)        {}
+func (udpEchoListener) OnError(getty.Session, error) {}
+func (udpEchoListener) OnCron(getty.Session)         {}
+func (udpEchoListener) OnMessage(ss getty.Session, pkg any) {
+	ctx, ok := pkg.(getty.UDPContext)
+	if !ok {
+		return
+	}
+	_, _, _ = ss.WritePkg(ctx, 0)
 }
 
 // lengthPrefixedCodec frames each pkg as a 4-byte big-endian length plus body.
@@ -316,9 +356,42 @@ func newWriteSession(b *testing.B, codec getty.ReadWriter, compress getty.Compre
 	}
 }
 
+// latencyRecorder keeps one sample per round trip so a benchmark can report
+// tail percentiles. A mean hides the p99 that RPC users actually feel, and
+// ns/op alone cannot show it. Samples are written into a slice preallocated to
+// b.N, so recording costs an append into existing capacity, not an allocation.
+type latencyRecorder struct {
+	samples []time.Duration
+}
+
+func newLatencyRecorder(n int) *latencyRecorder {
+	return &latencyRecorder{samples: make([]time.Duration, 0, n)}
+}
+
+func (l *latencyRecorder) record(d time.Duration) {
+	l.samples = append(l.samples, d)
+}
+
+// report publishes p50/p99/p999 as user metrics. It is a no-op when nothing was
+// recorded, so a benchmark that fails early does not report zeros.
+func (l *latencyRecorder) report(b *testing.B) {
+	if len(l.samples) == 0 {
+		return
+	}
+	sorted := append([]time.Duration(nil), l.samples...)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+	percentile := func(p float64) float64 {
+		idx := int(float64(len(sorted)-1) * p)
+		return float64(sorted[idx].Nanoseconds())
+	}
+	b.ReportMetric(percentile(0.5), "p50-ns")
+	b.ReportMetric(percentile(0.99), "p99-ns")
+	b.ReportMetric(percentile(0.999), "p999-ns")
+}
+
 // benchEcho is a live getty client/server echo pair over loopback.
 type benchEcho struct {
-	srv        getty.StreamServer
+	srv        getty.Server
 	cli        getty.Client
 	sessions   []getty.Session
 	replies    chan struct{}
@@ -340,14 +413,20 @@ func newBenchEcho(b *testing.B, transport string, codec getty.ReadWriter, compre
 	// a server and its event loop behind for the rest of the run.
 	b.Cleanup(e.close)
 
+	// udp is one shared server session over a packet conn, so it has no pool and
+	// no per-connection framing: the datagram is the message.
+	if transport == "udp" {
+		return newBenchUDPEcho(b, e, codec)
+	}
+
 	switch transport {
 	case "tcp":
-		e.srv = getty.NewTCPServer(getty.WithLocalAddress("127.0.0.1:0")).(getty.StreamServer)
+		e.srv = getty.NewTCPServer(getty.WithLocalAddress("127.0.0.1:0"))
 	case "ws":
 		e.srv = getty.NewWSServer(
 			getty.WithLocalAddress("127.0.0.1:0"),
 			getty.WithWebsocketServerPath(wsPath),
-		).(getty.StreamServer)
+		)
 	default:
 		b.Fatalf("unknown transport %q", transport)
 	}
@@ -356,7 +435,7 @@ func newBenchEcho(b *testing.B, transport string, codec getty.ReadWriter, compre
 		return nil
 	})
 
-	addr := e.srv.Listener().Addr().String()
+	addr := e.srv.(getty.StreamServer).Listener().Addr().String()
 	switch transport {
 	case "tcp":
 		e.cli = getty.NewTCPClient(getty.WithServerAddress(addr), getty.WithConnectionNumber(conns))
@@ -395,6 +474,36 @@ func newBenchEcho(b *testing.B, transport string, codec getty.ReadWriter, compre
 		}
 	}
 
+	return e
+}
+
+// newBenchUDPEcho builds the udp variant: a packet endpoint serving one shared
+// session, and one connected udp client. Compression is not applied - getty does
+// not support it on udp.
+func newBenchUDPEcho(b *testing.B, e *benchEcho, codec getty.ReadWriter) *benchEcho {
+	b.Helper()
+
+	e.srv = getty.NewUDPEndPoint(getty.WithLocalAddress("127.0.0.1:0"))
+	e.srv.RunEventLoop(func(ss getty.Session) error {
+		setHandler(ss, codec, udpEchoListener{}, getty.CompressNone)
+		return nil
+	})
+	addr := e.srv.(getty.PacketServer).PacketConn().LocalAddr().String()
+
+	ready := make(chan getty.Session, 1)
+	e.cli = getty.NewUDPClient(getty.WithServerAddress(addr), getty.WithConnectionNumber(1))
+	go e.cli.RunEventLoop(func(ss getty.Session) error {
+		setHandler(ss, codec, replyListener{replies: e.replies}, getty.CompressNone)
+		ready <- ss
+		return nil
+	})
+
+	select {
+	case ss := <-ready:
+		e.sessions = append(e.sessions, ss)
+	case <-time.After(dialTimeout):
+		b.Fatal("udp client session did not come up")
+	}
 	return e
 }
 

--- a/benchmark/helper_test.go
+++ b/benchmark/helper_test.go
@@ -247,8 +247,13 @@ func drainListener(tb testing.TB) (string, func()) {
 		tb.Fatalf("net.Listen: %v", err)
 	}
 
-	var conns sync.Map
+	var (
+		conns    sync.Map
+		acceptWG sync.WaitGroup
+	)
+	acceptWG.Add(1)
 	go func() {
+		defer acceptWG.Done()
 		for {
 			conn, err := ln.Accept()
 			if err != nil {
@@ -263,6 +268,9 @@ func drainListener(tb testing.TB) (string, func()) {
 
 	return ln.Addr().String(), func() {
 		_ = ln.Close()
+		// The accept goroutine must be gone before the range below, otherwise it
+		// can store a connection that nothing will ever close.
+		acceptWG.Wait()
 		conns.Range(func(k, _ any) bool {
 			_ = k.(net.Conn).Close()
 			return true

--- a/benchmark/server/main.go
+++ b/benchmark/server/main.go
@@ -1,0 +1,224 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Command server is the getty side of the load-generator benchmark: a
+// standalone process so the client that drives it runs outside this binary,
+// with its own scheduler and heap. This is the arrangement that answers "how
+// much traffic can getty serve", as opposed to the in-process benchmarks in
+// ../*.go, which answer "what does this code path cost".
+//
+// Run it in one terminal and a load generator such as tcpkali in another:
+//
+//	go run ./benchmark/server -addr 127.0.0.1:12345 -mode echo
+//	tcpkali --workers 4 -c 100 -T 30s -e -m "PING\n" 127.0.0.1:12345
+//
+// -mode sink consumes everything without framing and reports receive
+// throughput; -mode echo frames on '\n' (tcpkali's message separator) and
+// writes each message back.
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"os"
+	"os/signal"
+	"sync/atomic"
+	"syscall"
+	"time"
+)
+
+import (
+	getty "github.com/AlexStocks/getty/transport"
+	gettylog "github.com/AlexStocks/getty/util"
+)
+
+var (
+	addr        = flag.String("addr", "127.0.0.1:12345", "listen address")
+	mode        = flag.String("mode", "echo", "echo (frame on \\n and write back) or sink (consume and drop)")
+	compress    = flag.String("compress", "", "zip or snappy; empty leaves the connection raw")
+	maxMsgLen   = flag.Int("max_msg_len", 1<<20, "session max message length")
+	statsEvery  = flag.Duration("stats", 5*time.Second, "how often to print counters, 0 disables")
+	readTimeout = flag.Duration("read_timeout", time.Minute, "session read timeout")
+
+	// logLevel defaults to error on purpose: getty logs every write at debug
+	// level, which costs more than the write itself for small messages. Run
+	// with -log_level debug to see that for yourself.
+	logLevel = flag.String("log_level", "error", "debug|info|warn|error|fatal")
+)
+
+type counters struct {
+	msgs  atomic.Int64
+	bytes atomic.Int64
+}
+
+// lineCodec frames on '\n' and keeps a copy of the message, so it stays valid
+// after the session reuses its read buffer.
+type lineCodec struct{ c *counters }
+
+func (l lineCodec) Read(_ getty.Session, data []byte) (any, int, error) {
+	idx := bytes.IndexByte(data, '\n')
+	if idx < 0 {
+		return nil, 0, nil
+	}
+	line := make([]byte, idx+1)
+	copy(line, data[:idx+1])
+	l.c.msgs.Add(1)
+	l.c.bytes.Add(int64(idx + 1))
+	return line, idx + 1, nil
+}
+
+func (lineCodec) Write(_ getty.Session, pkg any) ([]byte, error) {
+	body, ok := pkg.([]byte)
+	if !ok {
+		return nil, fmt.Errorf("lineCodec: unexpected pkg type %T", pkg)
+	}
+	return body, nil
+}
+
+// sinkPkg is a non-nil placeholder: handleTCPPackage stops consuming the read
+// buffer as soon as a codec returns a nil pkg ("need more data"), so a sink
+// codec that returned nil would let the buffer grow until the session hit
+// maxMsgLen and closed.
+var sinkPkg = struct{}{}
+
+// sinkCodec consumes whatever arrived and delivers nothing: it measures the
+// read path with no framing or echo work in the way.
+type sinkCodec struct{ c *counters }
+
+func (s sinkCodec) Read(_ getty.Session, data []byte) (any, int, error) {
+	s.c.bytes.Add(int64(len(data)))
+	return sinkPkg, len(data), nil
+}
+
+func (s sinkCodec) Write(_ getty.Session, pkg any) ([]byte, error) {
+	body, ok := pkg.([]byte)
+	if !ok {
+		return nil, fmt.Errorf("sinkCodec: unexpected pkg type %T", pkg)
+	}
+	return body, nil
+}
+
+type echoListener struct{}
+
+func (echoListener) OnOpen(getty.Session) error   { return nil }
+func (echoListener) OnClose(getty.Session)        {}
+func (echoListener) OnError(getty.Session, error) {}
+func (echoListener) OnCron(getty.Session)         {}
+func (echoListener) OnMessage(ss getty.Session, pkg any) {
+	_, _, _ = ss.WritePkg(pkg, 0)
+}
+
+type sinkListener struct{}
+
+func (sinkListener) OnOpen(getty.Session) error   { return nil }
+func (sinkListener) OnClose(getty.Session)        {}
+func (sinkListener) OnError(getty.Session, error) {}
+func (sinkListener) OnCron(getty.Session)         {}
+func (sinkListener) OnMessage(getty.Session, any) {}
+
+func main() {
+	flag.Parse()
+
+	if err := setLogLevel(*logLevel); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(2)
+	}
+
+	c := &counters{}
+	var (
+		handler  getty.ReadWriter
+		listener getty.EventListener
+	)
+	switch *mode {
+	case "echo":
+		handler, listener = lineCodec{c}, echoListener{}
+	case "sink":
+		handler, listener = sinkCodec{c}, sinkListener{}
+	default:
+		fmt.Fprintf(os.Stderr, "unknown -mode %q, want echo or sink\n", *mode)
+		os.Exit(2)
+	}
+
+	srv := getty.NewTCPServer(getty.WithLocalAddress(*addr))
+	srv.RunEventLoop(func(ss getty.Session) error {
+		ss.SetPkgHandler(handler)
+		ss.SetEventListener(listener)
+		ss.SetMaxMsgLen(*maxMsgLen)
+		ss.SetReadTimeout(*readTimeout)
+		ss.SetWriteTimeout(time.Minute)
+		switch *compress {
+		case "":
+		case "zip":
+			ss.SetCompressType(getty.CompressZip)
+		case "snappy":
+			ss.SetCompressType(getty.CompressSnappy)
+		default:
+			return fmt.Errorf("unknown -compress %q, want zip or snappy", *compress)
+		}
+		return nil
+	})
+
+	fmt.Printf("getty server listening on %s mode=%s compress=%q\n",
+		srv.(getty.StreamServer).Listener().Addr().String(), *mode, *compress)
+	_ = os.Stdout.Sync()
+
+	if *statsEvery > 0 {
+		go reportStats(c, *statsEvery)
+	}
+
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
+	<-sig
+	srv.Close()
+}
+
+func setLogLevel(level string) error {
+	levels := map[string]gettylog.LoggerLevel{
+		"debug": gettylog.LoggerLevelDebug,
+		"info":  gettylog.LoggerLevelInfo,
+		"warn":  gettylog.LoggerLevelWarn,
+		"error": gettylog.LoggerLevelError,
+		"fatal": gettylog.LoggerLevelFatal,
+	}
+	l, ok := levels[level]
+	if !ok {
+		return fmt.Errorf("unknown -log_level %q", level)
+	}
+	if err := gettylog.SetLoggerLevel(l); err != nil {
+		return fmt.Errorf("SetLoggerLevel(%s): %w", level, err)
+	}
+	return nil
+}
+
+func reportStats(c *counters, every time.Duration) {
+	var lastBytes, lastMsgs int64
+	last := time.Now()
+	for range time.Tick(every) {
+		now := time.Now()
+		elapsed := now.Sub(last).Seconds()
+		bytes, msgs := c.bytes.Load(), c.msgs.Load()
+		fmt.Printf("[%s] recv %.2f Mbit/s (%.2f MB/s) msgs/s=%.0f total=%.1f MB\n",
+			now.Format("15:04:05"),
+			float64(bytes-lastBytes)*8/elapsed/1e6,
+			float64(bytes-lastBytes)/elapsed/1e6,
+			float64(msgs-lastMsgs)/elapsed,
+			float64(bytes)/1e6)
+		_ = os.Stdout.Sync()
+		lastBytes, lastMsgs, last = bytes, msgs, now
+	}
+}

--- a/benchmark/server/main.go
+++ b/benchmark/server/main.go
@@ -139,6 +139,24 @@ func main() {
 		os.Exit(2)
 	}
 
+	// Validate the flags the way -mode and -log_level are validated. A bad
+	// -compress used to be rejected per connection inside the session callback,
+	// whose error is only logged at warn level - below this program's default
+	// -log_level error - so the server accepted and dropped every connection and
+	// the cause never appeared anywhere.
+	var compressType getty.CompressType
+	switch *compress {
+	case "":
+		compressType = getty.CompressNone
+	case "zip":
+		compressType = getty.CompressZip
+	case "snappy":
+		compressType = getty.CompressSnappy
+	default:
+		fmt.Fprintf(os.Stderr, "unknown -compress %q, want zip or snappy\n", *compress)
+		os.Exit(2)
+	}
+
 	c := &counters{}
 	var (
 		handler  getty.ReadWriter
@@ -161,14 +179,8 @@ func main() {
 		ss.SetMaxMsgLen(*maxMsgLen)
 		ss.SetReadTimeout(*readTimeout)
 		ss.SetWriteTimeout(time.Minute)
-		switch *compress {
-		case "":
-		case "zip":
-			ss.SetCompressType(getty.CompressZip)
-		case "snappy":
-			ss.SetCompressType(getty.CompressSnappy)
-		default:
-			return fmt.Errorf("unknown -compress %q, want zip or snappy", *compress)
+		if compressType != getty.CompressNone {
+			ss.SetCompressType(compressType)
 		}
 		return nil
 	})

--- a/benchmark/session_test.go
+++ b/benchmark/session_test.go
@@ -18,6 +18,7 @@
 package benchmark
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"testing"
@@ -234,13 +235,17 @@ func BenchmarkSessionLifecycle(b *testing.B) {
 	})
 	addr := srv.(getty.StreamServer).Listener().Addr().String()
 	b.Cleanup(srv.Close)
+	// A bare net.Dial has no timeout, so a stalled connect would be charged to
+	// the measured loop.
+	dialer := &net.Dialer{Timeout: dialTimeout}
+	ctx := context.Background()
 	b.ReportAllocs()
 	b.StartTimer()
 
 	for i := 0; i < b.N; i++ {
-		conn, err := net.Dial("tcp", addr)
+		conn, err := dialer.DialContext(ctx, "tcp", addr)
 		if err != nil {
-			b.Fatalf("net.Dial: %v", err)
+			b.Fatalf("dial %s: %v", addr, err)
 		}
 		<-accepted
 		// Reset rather than FIN: a benchmark that dials in a tight loop would

--- a/benchmark/session_test.go
+++ b/benchmark/session_test.go
@@ -201,18 +201,24 @@ func BenchmarkSessionAccessors(b *testing.B) {
 	b.StopTimer()
 	ss := newWriteSession(b, nopCodec{}, getty.CompressNone)
 
-	benches := map[string]func(){
-		"IsClosed":     func() { _ = ss.IsClosed() },
-		"Stat":         func() { _ = ss.Stat() },
-		"EndPoint":     func() { _ = ss.EndPoint() },
-		"WriteTimeout": func() { _ = ss.WriteTimeout() },
-		"GetAttribute": func() { _ = ss.GetAttribute("missing") },
+	// an ordered slice, not a map: these sub-benchmarks share one session, so
+	// whichever runs first pays its cold start, and a map would reshuffle that
+	// cost between runs of what is meant to be a comparable measurement
+	benches := []struct {
+		name string
+		fn   func()
+	}{
+		{"IsClosed", func() { _ = ss.IsClosed() }},
+		{"Stat", func() { _ = ss.Stat() }},
+		{"EndPoint", func() { _ = ss.EndPoint() }},
+		{"WriteTimeout", func() { _ = ss.WriteTimeout() }},
+		{"GetAttribute", func() { _ = ss.GetAttribute("missing") }},
 	}
-	for name, fn := range benches {
-		b.Run(name, func(b *testing.B) {
+	for _, bc := range benches {
+		b.Run(bc.name, func(b *testing.B) {
 			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {
-				fn()
+				bc.fn()
 			}
 		})
 	}

--- a/benchmark/session_test.go
+++ b/benchmark/session_test.go
@@ -1,0 +1,326 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package benchmark
+
+import (
+	"fmt"
+	"net"
+	"testing"
+	"time"
+)
+
+import (
+	getty "github.com/AlexStocks/getty/transport"
+)
+
+// The benchmarks in this file measure the write path of one getty session
+// against a peer that throws the bytes away. The cost of a real socket write is
+// part of every number - that is the point: they measure what a caller of the
+// public API actually pays. Compare them against each other and against the
+// same benchmark on another revision, not against another machine.
+// BenchmarkSessionWriteBytes is the entry point codecs use for the bulk path.
+// Sizes on both sides of maxPacketLen are covered because the lock and the
+// number of socket writes change exactly at that boundary.
+func BenchmarkSessionWriteBytes(b *testing.B) {
+	for _, size := range sizes {
+		b.Run(sizeName(size), func(b *testing.B) {
+			b.StopTimer()
+			ss := newWriteSession(b, nopCodec{}, getty.CompressNone)
+			payload := benchPayload(size)
+			b.SetBytes(int64(size))
+			b.ReportAllocs()
+			b.StartTimer()
+
+			for i := 0; i < b.N; i++ {
+				if _, err := ss.WriteBytes(payload); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkSessionWritePkg adds the codec call and, for a positive timeout, the
+// packetLock write lock plus the connection-level write deadline save/restore.
+func BenchmarkSessionWritePkg(b *testing.B) {
+	for _, timeout := range []time.Duration{0, time.Second} {
+		for _, size := range sizes {
+			b.Run(fmt.Sprintf("%s/timeout=%s", sizeName(size), timeout), func(b *testing.B) {
+				b.StopTimer()
+				ss := newWriteSession(b, nopCodec{}, getty.CompressNone)
+				payload := benchPayload(size)
+				b.SetBytes(int64(size))
+				b.ReportAllocs()
+				b.StartTimer()
+
+				for i := 0; i < b.N; i++ {
+					if _, _, err := ss.WritePkg(payload, timeout); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		}
+	}
+}
+
+// BenchmarkSessionSend is the raw public write entry point, kept next to
+// WriteBytes so the cost of the two paths can be compared directly.
+func BenchmarkSessionSend(b *testing.B) {
+	for _, size := range sizes {
+		b.Run(sizeName(size), func(b *testing.B) {
+			b.StopTimer()
+			ss := newWriteSession(b, nopCodec{}, getty.CompressNone)
+			payload := benchPayload(size)
+			b.SetBytes(int64(size))
+			b.ReportAllocs()
+			b.StartTimer()
+
+			for i := 0; i < b.N; i++ {
+				if _, err := ss.Send(payload); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkSessionWriteParallel drives the same session from GOMAXPROCS
+// goroutines. Below maxPacketLen all writers hold the packetLock read lock and
+// run concurrently; above it the fragmenting writer takes the write lock and
+// serializes them, which is the contention the packetLock exists for.
+func BenchmarkSessionWriteParallel(b *testing.B) {
+	for _, size := range sizes {
+		b.Run(sizeName(size), func(b *testing.B) {
+			b.StopTimer()
+			ss := newWriteSession(b, nopCodec{}, getty.CompressNone)
+			payload := benchPayload(size)
+			b.SetBytes(int64(size))
+			b.ReportAllocs()
+			b.StartTimer()
+
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					if _, err := ss.WriteBytes(payload); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		})
+	}
+}
+
+// BenchmarkSessionWriteBytesArray covers the batched path. For TCP it goes to
+// conn.Send([][]byte) under one packetLock read lock, so the whole array is
+// written before any other writer can interleave.
+//
+// The batch is rebuilt from one backing array on every iteration on purpose:
+// WriteBytesArray hands the caller's slice to net.Buffers, whose WriteTo
+// consumes it ("the buffers are consumed as they are written"), truncating the
+// caller's own []byte headers in place. A caller that reuses a batch therefore
+// writes zero bytes from the second call on, with a nil error. Re-slicing keeps
+// this benchmark measuring getty instead of that footgun, without copying any
+// payload.
+func BenchmarkSessionWriteBytesArray(b *testing.B) {
+	const pkgSize = 1 << 10
+	for _, n := range []int{1, 4, 16} {
+		b.Run(fmt.Sprintf("%dpkg", n), func(b *testing.B) {
+			b.StopTimer()
+			ss := newWriteSession(b, nopCodec{}, getty.CompressNone)
+			backing := benchPayload(n * pkgSize)
+			pkgs := make([][]byte, n)
+			b.SetBytes(int64(n * pkgSize))
+			b.ReportAllocs()
+			b.StartTimer()
+
+			for i := 0; i < b.N; i++ {
+				for j := range pkgs {
+					pkgs[j] = backing[j*pkgSize : (j+1)*pkgSize]
+				}
+				if _, err := ss.WriteBytesArray(pkgs...); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkSessionCompression isolates the connection-level codec: each write
+// flushes one compressed frame. "raw" installs no codec at all, which is
+// getty's default.
+func BenchmarkSessionCompression(b *testing.B) {
+	for _, tc := range []struct {
+		name     string
+		compress getty.CompressType
+	}{
+		{"raw", getty.CompressNone},
+		{"zip", getty.CompressZip},
+		{"bestspeed", getty.CompressBestSpeed},
+		{"bestcompression", getty.CompressBestCompression},
+		{"huffman", getty.CompressHuffman},
+		{"snappy", getty.CompressSnappy},
+	} {
+		for _, size := range []int{1 << 10, 64 << 10} {
+			b.Run(tc.name+"/"+sizeName(size), func(b *testing.B) {
+				b.StopTimer()
+				ss := newWriteSession(b, nopCodec{}, tc.compress)
+				payload := benchPayload(size)
+				b.SetBytes(int64(size))
+				b.ReportAllocs()
+				b.StartTimer()
+
+				for i := 0; i < b.N; i++ {
+					if _, err := ss.WriteBytes(payload); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		}
+	}
+}
+
+// BenchmarkSessionAccessors covers the session methods that take the session
+// lock on every call, so a change in lock scope on them is visible. They do not
+// touch the socket, but they need a live session to run against.
+func BenchmarkSessionAccessors(b *testing.B) {
+	b.StopTimer()
+	ss := newWriteSession(b, nopCodec{}, getty.CompressNone)
+
+	benches := map[string]func(){
+		"IsClosed":     func() { _ = ss.IsClosed() },
+		"Stat":         func() { _ = ss.Stat() },
+		"EndPoint":     func() { _ = ss.EndPoint() },
+		"WriteTimeout": func() { _ = ss.WriteTimeout() },
+		"GetAttribute": func() { _ = ss.GetAttribute("missing") },
+	}
+	for name, fn := range benches {
+		b.Run(name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				fn()
+			}
+		})
+	}
+}
+
+// BenchmarkSessionLifecycle measures the fixed cost of taking on a connection:
+// dial, accept, session callback, and teardown. The client side is a bare
+// socket so the number is the server's session lifecycle plus the handshake.
+func BenchmarkSessionLifecycle(b *testing.B) {
+	b.StopTimer()
+	silenceLogs()
+
+	srv := getty.NewTCPServer(getty.WithLocalAddress("127.0.0.1:0"))
+	accepted := make(chan struct{}, 64)
+	srv.RunEventLoop(func(ss getty.Session) error {
+		ss.SetPkgHandler(nopCodec{})
+		ss.SetEventListener(discardListener{})
+		accepted <- struct{}{}
+		return nil
+	})
+	addr := srv.(getty.StreamServer).Listener().Addr().String()
+	b.Cleanup(srv.Close)
+	b.ReportAllocs()
+	b.StartTimer()
+
+	for i := 0; i < b.N; i++ {
+		conn, err := net.Dial("tcp", addr)
+		if err != nil {
+			b.Fatalf("net.Dial: %v", err)
+		}
+		<-accepted
+		// Reset rather than FIN: a benchmark that dials in a tight loop would
+		// otherwise fill the ephemeral port range with TIME_WAIT sockets and
+		// fail with "can't assign requested address" long before benchtime.
+		if tcp, ok := conn.(*net.TCPConn); ok {
+			_ = tcp.SetLinger(0)
+		}
+		if err := conn.Close(); err != nil {
+			b.Fatalf("conn.Close: %v", err)
+		}
+	}
+}
+
+// newUDPWriteSession returns a getty UDP client session pointed at a socket
+// that drains, so the datagram path can be measured with the syscall included.
+func newUDPWriteSession(b *testing.B) getty.Session {
+	b.Helper()
+	silenceLogs()
+
+	peer, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	if err != nil {
+		b.Skipf("loopback udp unavailable: %v", err)
+	}
+	go func() {
+		buf := make([]byte, 64<<10)
+		for {
+			if _, _, err := peer.ReadFromUDP(buf); err != nil {
+				return
+			}
+		}
+	}()
+
+	ready := make(chan getty.Session, 1)
+	cli := getty.NewUDPClient(
+		getty.WithServerAddress(peer.LocalAddr().String()),
+		getty.WithConnectionNumber(1),
+	)
+	go cli.RunEventLoop(func(ss getty.Session) error {
+		ss.SetPkgHandler(udpCodec{})
+		ss.SetEventListener(discardListener{})
+		ss.SetReadTimeout(time.Minute)
+		ss.SetWriteTimeout(time.Minute)
+		ready <- ss
+		return nil
+	})
+	b.Cleanup(func() {
+		cli.Close()
+		_ = peer.Close()
+	})
+
+	select {
+	case ss := <-ready:
+		return ss
+	case <-time.After(dialTimeout):
+		b.Fatal("udp client session did not come up")
+		return nil
+	}
+}
+
+// BenchmarkUDPSend measures the datagram path. Sizes stay under the smallest
+// common datagram limit (macOS caps a UDP datagram at 9216 bytes by default),
+// so the write is always measurable here.
+func BenchmarkUDPSend(b *testing.B) {
+	b.StopTimer()
+	ss := newUDPWriteSession(b)
+
+	for _, size := range []int{64, 1 << 10, 4 << 10} {
+		b.Run(sizeName(size), func(b *testing.B) {
+			b.StopTimer()
+			ctx := getty.UDPContext{Pkg: benchPayload(size)}
+			b.SetBytes(int64(size))
+			b.ReportAllocs()
+			b.StartTimer()
+
+			for i := 0; i < b.N; i++ {
+				if _, _, err := ss.WritePkg(ctx, 0); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
getty has no benchmarks, so every change to the hot path - lock scope, write fragmentation, codec choice, heartbeat timer, session lifecycle - has to be argued without numbers. This adds two kinds of measurement, because they answer different questions.

## Shape

`benchmark/` is its own package and uses **nothing but the public API**, exactly like a library user, so the library's own tests stay free of measurement code.

**Code-path benchmarks** (`go test -bench` in this package) report `ns/op`, `MB/s`, `allocs/op` and, for round trips, **p50/p99/p999 latency** as user metrics - a mean hides the tail, and the tail is what an RPC user feels.

| File | Covers |
|---|---|
| `benchmark/session_test.go` | one real client session writing to a peer that discards: `WriteBytes`, `WritePkg` (timeout 0 / >0), `Send`, `WriteBytesArray`, `RunParallel` across 64B / 1K / 16K / **16K+1** / 64K / 1M; `SessionCompression` (raw / zip / bestspeed / bestcompression / huffman / snappy); `SessionAccessors`; connection churn; UDP `Send` |
| `benchmark/echo_test.go` | a real client/server pair over loopback: `EchoPingPong` (tcp, ws), `EchoUDP`, `EchoPipeline` (in-flight 1/8/64), `EchoCodec` (binary vs json), `EchoCompression` (raw/zip/snappy), `EchoConnections` (1/8/64) |
| `benchmark/server/main.go` | the standalone server for the external load test (below) |

16K is `maxPacketLen`, where `WriteBytes` switches from the read-locked single send to the write-locked fragmenting loop, so both sides of that boundary are measured.

```
make bench          # every case, ~7 min at -benchtime=1s
make bench-echo     # only the client/server echo cases
make bench-stable   # -count=5, for numbers worth quoting
```

None of it is in the CI gate: every case touches a real loopback socket, so absolute numbers move with the machine. One run is noisy - a few percent means nothing until it survives repetition:

```
make bench-stable > old.txt && git switch my-change && make bench-stable > new.txt
benchstat old.txt new.txt
```

## Load test (external generator)

`benchmark/server` is a standalone getty process, meant to be driven from outside so the load client shares neither the server's scheduler nor its heap - the arrangement `apache/dubbo-getty`'s `benchmark/` uses:

```
make bench-server                                                  # terminal 1
tcpkali --workers 4 -c 100 -T 30s -e -m "PING\n" 127.0.0.1:12345  # terminal 2
```

`-mode sink` consumes without framing and reports receive throughput; `-mode echo` frames on `\n` and writes each message back. tcpkali can also report latency percentiles for echo mode, since the echoed message is a usable marker.

Apple M1, loopback, 6-byte messages, tcpkali 1.1.1:

| Mode | Connections | Duration | Result |
|---|---|---|---|
| sink | 10 | 30s | **53.0-53.3 Gbit/s (6.6 GB/s)** received |
| sink | 100 | 30s | 43.6-47.4 Gbit/s (5.5-5.9 GB/s) received |
| echo | 100 | 15s | **362k-451k msg/s** echoed, `-log_level error` |
| echo | 100 | 15s | 77k-100k msg/s echoed, `-log_level debug` |

Two things to read out of that:

- Receive throughput does **not** grow with the connection count (53 -> 45 Gbit/s from 10 to 100 connections): the per-session read path is the limit, not the accept path. That is the same shape `apache/dubbo-getty`'s `benchmark/compare-gnet/bench.md` reports, where gnet degrades under concurrency while getty stays flat. The absolute numbers are not comparable - that table is an 8-core Intel Mac in 2020 on getty v1.4.8, reporting 1902 Mbps at 10 connections.
- The echo path is **~4x faster with logging off**: same binary, same load, 362k-451k msg/s at `-log_level error` against 77k-100k msg/s at `-log_level debug`. That is finding 3 below, measured under load.

## Baseline

Apple M1, darwin/arm64, go1.25.0, GOMAXPROCS 8, `-benchtime=1s -count=3`, medians, measured on master `4207b65` - so the `Send` and accessor rows already carry #141 and #142 (e.g. `SessionAccessors/WriteTimeout` is 17.7 ns with the nil-guarded method, against 2.6 ns for the bare promoted load it replaced).

<details>
<summary>Write path</summary>

```

SessionWriteBytes/64                       2.15 us     3 allocs      112 B/op
SessionWriteBytes/1K                       2.31 us     4 allocs      120 B/op
SessionWriteBytes/16K                      2.83 us     4 allocs      120 B/op
SessionWriteBytes/16K+1                    5.18 us     7 allocs      232 B/op   <- fragmentation starts
SessionWriteBytes/64K                     11.59 us    16 allocs      480 B/op
SessionWriteBytes/1M                     190.83 us   256 allocs     7680 B/op
SessionSend/64                             2.59 us     3 allocs      112 B/op
SessionSend/1M                           171.50 us     4 allocs      120 B/op   <- one socket write, no fragmenting
SessionWritePkg/64/timeout=0s              2.45 us     4 allocs      136 B/op
SessionWritePkg/16K+1/timeout=0s           3.23 us     5 allocs      144 B/op   <- no fragment jump
SessionWritePkg/1K/timeout=1s              2.77 us     5 allocs      144 B/op   <- write-lock timeout window
SessionWriteParallel/16K                   4.31 us     4 allocs      120 B/op
SessionWriteParallel/16K+1                 7.06 us     7 allocs      232 B/op   <- write lock serializes the writers
SessionWriteBytesArray/1pkg                2.83 us     4 allocs      120 B/op
SessionWriteBytesArray/4pkg                3.17 us     5 allocs      144 B/op   <- one writev
SessionWriteBytesArray/16pkg               3.97 us     5 allocs      144 B/op
```

</details>

<details>
<summary>Codec, accessors, lifecycle, udp send</summary>

```

SessionCompression/raw/64K                14.18 us    16 allocs      480 B/op
SessionCompression/snappy/64K             77.72 us    16 allocs      480 B/op
SessionCompression/bestspeed/64K          66.33 us    20 allocs      576 B/op
SessionCompression/zip/64K               165.82 us    20 allocs      576 B/op
SessionCompression/snappy/1K               5.21 us     4 allocs      120 B/op
SessionCompression/zip/1K                 11.06 us     5 allocs      144 B/op
SessionCompression/huffman/1K             33.50 us     8 allocs      216 B/op   <- see note below
SessionAccessors/IsClosed                  15.1 ns     0 allocs        0 B/op
SessionAccessors/EndPoint                  14.8 ns     0 allocs        0 B/op
SessionAccessors/GetAttribute              23.6 ns     0 allocs        0 B/op
SessionAccessors/WriteTimeout              17.7 ns     0 allocs        0 B/op
SessionAccessors/Stat                     443.3 ns     7 allocs      276 B/op
SessionLifecycle                         109.87 us    92 allocs     8932 B/op
UDPSend/64                                 3.74 us     5 allocs      148 B/op
UDPSend/4K                                 3.59 us     6 allocs      156 B/op
```

</details>

<details>
<summary>Loopback echo, with tail latency</summary>

```
                                       ns/op       p50       p99      MB/s
EchoPingPong/tcp/64                 19.40 us   18.6 us   32.5 us       3.3 MB/s
EchoPingPong/tcp/1K                 20.70 us   19.8 us   37.8 us      49.5 MB/s
EchoPingPong/tcp/16K                47.91 us   37.5 us  149.0 us     342.0 MB/s
EchoPingPong/tcp/64K               110.82 us   85.2 us  249.2 us     591.4 MB/s
EchoPingPong/ws/64                  21.17 us   19.5 us   39.4 us       3.0 MB/s
EchoPingPong/ws/1K                  23.09 us   22.2 us   46.2 us      44.4 MB/s
EchoPingPong/ws/3K                  27.04 us   25.0 us   82.2 us     113.6 MB/s
EchoUDP/64                          20.80 us   19.8 us   40.5 us       3.1 MB/s
EchoUDP/1K                          21.73 us   20.6 us   47.5 us      47.1 MB/s
EchoUDP/4K                          22.85 us   22.0 us   57.5 us     179.2 MB/s

EchoPipeline/inflight=1/1K          20.96 us      48.9 MB/s  19 allocs
EchoPipeline/inflight=8/1K           4.55 us     225.1 MB/s  18 allocs
EchoPipeline/inflight=64/1K          3.93 us     260.9 MB/s  17 allocs
EchoCodec/binary/16K                43.29 us     378.5 MB/s  30 allocs
EchoCodec/json/16K                 264.39 us      62.0 MB/s  43 allocs
EchoCompression/raw/16K             43.41 us     377.4 MB/s  31 allocs
EchoCompression/snappy/16K          84.28 us     194.4 MB/s  33 allocs
EchoCompression/zip/16K            118.12 us     138.7 MB/s  32 allocs
EchoConnections/conns=1             21.01 us      48.7 MB/s  19 allocs
EchoConnections/conns=64            21.70 us      47.2 MB/s  19 allocs
```

The ws rows stop at 3K for the reason in finding 2. `EchoConnections` is flat up to 64 sessions because it keeps one request in flight at a time.

</details>

## Findings

**1. `Session.WriteBytesArray` truncates the caller's own buffers (silent data loss).**
`gettyTCPConn.Send` hands the caller's `[][]byte` to `net.Buffers` and calls `WriteTo`:

```go
netBuf := net.Buffers(buffers)
lg, err = netBuf.WriteTo(t.conn)   // transport/connection.go
```

`net.Buffers.WriteTo` documents that "the buffers are consumed as they are written", and it consumes them through the caller's backing array. Five lines of stdlib reproduce it, no getty involved:

```go
pkgs := [][]byte{make([]byte, 1024), make([]byte, 1024), make([]byte, 1024), make([]byte, 1024)}
n, _ := net.Buffers(pkgs).WriteTo(conn)
// n=4096, but now len(pkgs[0]) == 0 and len(pkgs[1]) == 0
```

So a caller that reuses a batch gets `(0, nil)` from the second call on - a successful-looking write of nothing, with no warning from `Session.WriteBytesArray`. The benchmark hit this while measuring the batched path: reusing one batch produced a physically impossible 51 GB/s for 16x1KB (it was writing zero bytes). It now rebuilds the batch from one backing array per iteration and documents why.

**Fixed in #144**: `Send` now copies the slice headers into pooled scratch space, so only its own copy is consumed. This PR stays measurement-only.

**2. `Session.SetMaxMsgLen` cannot raise a websocket client's read limit.**
`buildWSClient` calls `conn.SetReadLimit(int64(ss.maxMsgLen))` right after `newWSSession`, i.e. **before** `NewSessionCallback` runs (`transport/client.go`, both the ws and wss constructors). The limit is therefore always the 4KB default, and a larger echo dies with `websocket: read limit exceeded` / close 1009 no matter what the callback does. The server does it the other way round and is correct (`transport/server.go`, after `newSession`). The benchmark keeps the ws payloads under 4KB for this reason. **Fixed in #144**: the limit is now applied in `client.connect()` after `newSession`, and once both land the ws dimension here can grow past 4KB.

**3. Every write paid for debug logging, and under load that dominated.** (fixed in #147)
`gettyTCPConn.Send` calls `log.Debugf` with `LocalAddr()`, `RemoteAddr()`, `length` and `err`. Even with the level disabled the `...any` arguments are boxed, which shows up as one allocation (the 64-byte `[]any` backing array) and 64 B/op per write:

```
with    log.Debugf:  112 B/op   3 allocs/op     (SessionSend/64)
without log.Debugf:   48 B/op   2 allocs/op
```

With a real socket that cost is below the noise floor of the in-process benchmarks - but it is not negligible under load. Driving the standalone server with tcpkali at 100 connections, the same binary echoes **362k-451k msg/s with `-log_level error` and 77k-100k msg/s with `-log_level debug`**, a ~4x difference from logging alone; at debug level the server wrote 2.28 million log lines in 15 seconds.

**4. `WritePkg` never fragments, `WriteBytes` does.**
`WritePkg` hands the encoded pkg to one `conn.Send`, so it does not jump at the 16K boundary, whereas `WriteBytes` splits above `maxPacketLen` and takes the write lock. See the rows above: `SessionWriteBytes` jumps at 16K+1 while `SessionWritePkg` stays flat. Worth documenting rather than changing, but the two public write paths behave very differently for large payloads.

**5. `CompressHuffman` is slow on small payloads - a `compress/flate` property, not a getty bug.**
`CompressHuffman` maps to `flate.HuffmanOnly` (`transport/const.go`) and that mapping is correct. Measured against `compress/flate` directly - a persistent writer with Write + Flush per operation, which is exactly what getty's `writeFlusher` does - with no getty involved:

```
1 KB                       flush per op    no flush
  default(-1)                  3.15 us      2.10 us
  bestcompression(9)           3.18 us      2.09 us
  huffmanonly(-2)             21.65 us      0.75 us
64 KB
  default(-1)                 138.24 us
  huffmanonly(-2)              50.71 us
```

`HuffmanOnly` skips LZ77 matching, which is cheap per byte, but it pays ~20 us for the block it must emit at every `Flush` - and getty flushes after every write so that each pkg reaches the peer. On 1 KB that per-block cost dominates (7x `bestspeed`); on 64 KB the skipped match search wins and it is 2.7x faster than `default`. The rows above reproduce the standard library faithfully.

Practical reading: keep `snappy` or `bestspeed` for small messages; `huffman` is a large-payload choice, and the profile comes from the standard library rather than from getty.

## Relationship to apache/dubbo-getty

`apache/getty` redirects to `apache/dubbo-getty`, a flat-layout sibling of this repository (same `session.Send`), and it benchmarks differently: `benchmark/{server,client,loop_client}/main.go` are standalone load-test processes driven by an external generator, and `benchmark/compare-gnet/bench.md` records whole-framework bandwidth against gnet. Those numbers answer "how much total throughput under an external flood"; the `go test -bench` half of this package answers "what does each code path cost, and did my change move it". The external half here is the same shape as theirs, which is what makes a comparison possible at all.

## Notes for reviewers

- Setup is bracketed by `b.StopTimer()`/`b.StartTimer()`. `b.ResetTimer()` does **not** restart a stopped timer, which silently measured 0 ns/op and made `-benchtime=1s` extrapolate `N` into an effective hang.
- Library logging is silenced, otherwise `gettyTCPConn.Send`'s per-write logging dominates the numbers and benign teardown errors (a closed `http.Server`) garble the output. The standalone server defaults to `-log_level error` for the same reason.
- The echo harness raises `SetMaxMsgLen` and keeps ws under 4KB (finding 2); `waitReply` and the dial timeout fail loudly, which is how finding 2 was found.
- The connection-churn case resets the client socket (`SetLinger(0)`) instead of closing with FIN: a tight dial loop otherwise exhausts the ephemeral port range with TIME_WAIT sockets and dies with `can't assign requested address`.
- `benchmark/doc.go` carries the workflow (benchstat, the tcpkali invocation, the flag list) so it does not live only in this PR description.
- Nothing here touches production code: `make test`, `make test-race`, `make check-fmt` and `make lint` are unaffected and clean.
