### PR TITLE
fix: keep WriteBytesArray from consuming the caller's buffers, and apply the ws read limit after newSession

### DIFF
--- a/transport/client.go
+++ b/transport/client.go
@@ -273,9 +273,6 @@ func (c *client) dialWS() Session {
 	}
 	if err == nil {
 		ss = newWSSession(conn, c)
-		if ss.(*session).maxMsgLen > 0 {
-			conn.SetReadLimit(int64(ss.(*session).maxMsgLen))
-		}
 
 		return ss
 	}
@@ -331,9 +328,6 @@ func (c *client) dialWSS() Session {
 	}
 	if err == nil {
 		ss = newWSSession(conn, c)
-		if ss.(*session).maxMsgLen > 0 {
-			conn.SetReadLimit(int64(ss.(*session).maxMsgLen))
-		}
 		ss.SetName(defaultWSSSessionName)
 
 		return ss
@@ -377,6 +371,18 @@ func (c *client) sessionNum() int {
 	return num
 }
 
+// applyWSReadLimit raises gorilla's read limit from the session's maxMsgLen. It
+// is a no-op for non-websocket connections.
+func applyWSReadLimit(ss Session) {
+	ws, ok := ss.(*session).Connection.(*gettyWSConn)
+	if !ok {
+		return
+	}
+	if maxMsgLen := ss.(*session).maxMsgLen; maxMsgLen > 0 {
+		ws.conn.SetReadLimit(int64(maxMsgLen))
+	}
+}
+
 func (c *client) connect() bool {
 	var (
 		err error
@@ -390,6 +396,13 @@ func (c *client) connect() bool {
 	}
 	err = c.newSession(ss)
 	if err == nil {
+		// NewSessionCallback is the documented place to ask for a bigger
+		// maxMsgLen, and gorilla's read limit can only change before the first
+		// read, so it has to be applied here and not while dialing - doing it
+		// there left a websocket client stuck with the 4KB default no matter
+		// what the callback asked for. The server already applies it after its
+		// own newSession call.
+		applyWSReadLimit(ss)
 		// Set the reconnect attributes before run(): session.stop() decides
 		// whether to reconnect from these attributes, so a connection that
 		// dies right after run() must already carry them, otherwise the

--- a/transport/client_test.go
+++ b/transport/client_test.go
@@ -23,9 +23,12 @@ import (
 	"errors"
 	"io"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -1247,4 +1250,82 @@ func TestNewWSSClient(t *testing.T) {
 	// time.Sleep(1000e9)
 	// server.Close()
 	// assert.True(t, server.IsClosed())
+}
+
+// wsEchoMsgListener reports the length of every pkg the session delivers.
+type wsEchoMsgListener struct{ echoed chan<- int }
+
+func (*wsEchoMsgListener) OnOpen(Session) error   { return nil }
+func (*wsEchoMsgListener) OnClose(Session)        {}
+func (*wsEchoMsgListener) OnError(Session, error) {}
+func (*wsEchoMsgListener) OnCron(Session)         {}
+func (l *wsEchoMsgListener) OnMessage(_ Session, pkg any) {
+	body, _ := pkg.(string)
+	l.echoed <- len(body)
+}
+
+// TestWSClientReadLimitFollowsSetMaxMsgLen pins that a websocket client actually
+// gets the maxMsgLen its NewSessionCallback asks for. gorilla's read limit can
+// only change before the first read, and the client used to set it while
+// dialing - before the callback ran - so it stayed at the 4KB default and any
+// larger message was rejected with "read limit exceeded".
+func TestWSClientReadLimitFollowsSetMaxMsgLen(t *testing.T) {
+	upgrader := websocket.Upgrader{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		for {
+			messageType, data, err := conn.ReadMessage()
+			if err != nil {
+				return
+			}
+			if err := conn.WriteMessage(messageType, data); err != nil {
+				return
+			}
+		}
+	}))
+	defer srv.Close()
+
+	// above the 4KB default maxMsgLen, below what the callback asks for
+	const payloadSize = 8 << 10
+	echoed := make(chan int, 4)
+	sessionCh := make(chan Session, 1)
+
+	client := NewWSClient(
+		WithServerAddress("ws"+strings.TrimPrefix(srv.URL, "http")),
+		WithConnectionNumber(1),
+	)
+	defer client.Close()
+
+	client.RunEventLoop(func(ss Session) error {
+		ss.SetReader(wholeFrameReader{})
+		ss.SetWriter(timeoutTestWriter{})
+		ss.SetEventListener(&wsEchoMsgListener{echoed: echoed})
+		ss.SetMaxMsgLen(64 << 10)
+		sessionCh <- ss
+		return nil
+	})
+
+	var ss Session
+	select {
+	case ss = <-sessionCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("client session did not come up")
+	}
+
+	if _, err := ss.WriteBytes(make([]byte, payloadSize)); err != nil {
+		t.Fatalf("WriteBytes: %v", err)
+	}
+
+	select {
+	case n := <-echoed:
+		if n != payloadSize {
+			t.Fatalf("echoed pkg length = %d, want %d", n, payloadSize)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("no echo for a payload above the 4KB default: the client read limit did not follow SetMaxMsgLen")
+	}
 }

--- a/transport/connection.go
+++ b/transport/connection.go
@@ -765,6 +765,17 @@ func (t *gettyTCPConn) recv(p []byte) (int, error) {
 	return length, t.codecReadError(err)
 }
 
+// buffersScratchPool hands out the slice-of-slice headers Send copies a batch
+// into. The copy exists because net.Buffers.WriteTo consumes (nils out) the
+// elements of the slice it is handed - see the [][]byte branch of Send - and a
+// pool keeps that from costing an allocation on every batched write.
+var buffersScratchPool = sync.Pool{
+	New: func() any {
+		bufs := make([][]byte, 0, 8)
+		return &bufs
+	},
+}
+
 // tcp connection write
 func (t *gettyTCPConn) Send(pkg any) (int, error) {
 	var (
@@ -803,8 +814,19 @@ func (t *gettyTCPConn) Send(pkg any) (int, error) {
 		// to t.conn and the peer receives a corrupt mix of coded and raw data.
 		if !codecEnabled {
 			// only a raw conn here, so writev the whole batch in one syscall.
-			netBuf := net.Buffers(buffers)
+			//
+			// net.Buffers.WriteTo consumes the slice it is given: its consume()
+			// nils out each element inside the *caller's* backing array
+			// (net/net.go), so handing it the caller's own batch means a caller
+			// that reuses it writes nothing from the second call on, and gets
+			// (0, nil) back. Copy the slice headers into scratch space so only
+			// this connection's copy is consumed; the payloads are still written
+			// by reference.
+			scratch := buffersScratchPool.Get().(*[][]byte)
+			*scratch = append((*scratch)[:0], buffers...)
+			netBuf := net.Buffers(*scratch)
 			lg, err = netBuf.WriteTo(t.conn)
+			buffersScratchPool.Put(scratch)
 		} else if bw, ok := writer.(buffersWriter); ok {
 			lg, err = bw.WriteBuffers(buffers)
 		} else {

--- a/transport/connection.go
+++ b/transport/connection.go
@@ -826,6 +826,15 @@ func (t *gettyTCPConn) Send(pkg any) (int, error) {
 			*scratch = append((*scratch)[:0], buffers...)
 			netBuf := net.Buffers(*scratch)
 			lg, err = netBuf.WriteTo(t.conn)
+			// consume() nils only the headers it wrote, so a partial write leaves
+			// the rest pointing at the caller's payloads. Clear every slot before
+			// the pool keeps the entry: a pooled scratch slice must not retain
+			// references to caller data until its next use.
+			slots := (*scratch)[:cap(*scratch)]
+			for i := range slots {
+				slots[i] = nil
+			}
+			*scratch = (*scratch)[:0]
 			buffersScratchPool.Put(scratch)
 		} else if bw, ok := writer.(buffersWriter); ok {
 			lg, err = bw.WriteBuffers(buffers)

--- a/transport/connection_test.go
+++ b/transport/connection_test.go
@@ -1042,3 +1042,28 @@ func TestCodecSendStallDetectionOutrunsLongPollInterval(t *testing.T) {
 		})
 	}
 }
+
+// TestConnectionSendBatchKeepsCallerBuffers pins the batched-write contract:
+// Send must not consume the caller's slice. net.Buffers.WriteTo nils out each
+// element of the slice it is handed (net/net.go consume), and Send used to hand
+// it the caller's own batch, so a caller reusing it wrote nothing from the
+// second call on while both calls still reported success - which is exactly
+// what Session.WriteBytesArray exposes to users.
+func TestConnectionSendBatchKeepsCallerBuffers(t *testing.T) {
+	conn := newGettyTCPConn(&timeoutAccessorNetConn{})
+	pkgs := [][]byte{[]byte("hello"), []byte("world")}
+
+	for i := 1; i <= 2; i++ {
+		lg, err := conn.Send(pkgs)
+		if err != nil {
+			t.Fatalf("Send call %d: %v", i, err)
+		}
+		if lg != 10 {
+			t.Fatalf("Send call %d wrote %d bytes, want 10", i, lg)
+		}
+		if len(pkgs[0]) != 5 || len(pkgs[1]) != 5 {
+			t.Fatalf("Send call %d consumed the caller's buffers: len(pkgs[0])=%d len(pkgs[1])=%d, want 5 and 5",
+				i, len(pkgs[0]), len(pkgs[1]))
+		}
+	}
+}

--- a/transport/connection_test.go
+++ b/transport/connection_test.go
@@ -1067,3 +1067,46 @@ func TestConnectionSendBatchKeepsCallerBuffers(t *testing.T) {
 		}
 	}
 }
+
+// partialWriteNetConn writes the requested prefix and then fails, so
+// net.Buffers.WriteTo consumes only part of the batch.
+type partialWriteNetConn struct {
+	prefix int
+}
+
+func (c *partialWriteNetConn) Read([]byte) (int, error) { return 0, io.EOF }
+func (c *partialWriteNetConn) Write(p []byte) (int, error) {
+	n := c.prefix
+	if n > len(p) {
+		n = len(p)
+	}
+	return n, perrors.New("write failed after a prefix")
+}
+func (*partialWriteNetConn) Close() error                     { return nil }
+func (*partialWriteNetConn) LocalAddr() net.Addr              { return &net.TCPAddr{} }
+func (*partialWriteNetConn) RemoteAddr() net.Addr             { return &net.TCPAddr{} }
+func (*partialWriteNetConn) SetDeadline(time.Time) error      { return nil }
+func (*partialWriteNetConn) SetReadDeadline(time.Time) error  { return nil }
+func (*partialWriteNetConn) SetWriteDeadline(time.Time) error { return nil }
+
+// TestBuffersScratchPoolDoesNotRetainPayloads pins that the pooled slice-of-slice
+// headers used by the batched write path are cleared before the entry goes back
+// to the pool. net.Buffers.consume nils only the headers it wrote, so after a
+// partial write the remaining slots still point at the caller's payloads, and a
+// pooled entry would keep them reachable.
+func TestBuffersScratchPoolDoesNotRetainPayloads(t *testing.T) {
+	conn := newGettyTCPConn(&partialWriteNetConn{prefix: 2})
+	pkgs := [][]byte{[]byte("first"), []byte("second"), []byte("third")}
+
+	if _, err := conn.Send(pkgs); err == nil {
+		t.Fatal("Send over a partially failing connection returned no error")
+	}
+
+	scratch := buffersScratchPool.Get().(*[][]byte)
+	defer buffersScratchPool.Put(scratch)
+	for i, slot := range (*scratch)[:cap(*scratch)] {
+		if slot != nil {
+			t.Fatalf("pooled scratch slot %d still references a payload (%d bytes)", i, len(slot))
+		}
+	}
+}


### PR DESCRIPTION
Fixes #126. Fixes #148.

Two correctness bugs that the benchmarks in #143 turned up while measuring code paths nobody had measured before. Both are silent from the caller's point of view, and both have a regression test that fails on master.

## 1. `Session.WriteBytesArray` destroyed the caller's batch (issue #148)

`gettyTCPConn.Send` handed the caller's `[][]byte` straight to `net.Buffers`:

```go
netBuf := net.Buffers(buffers)
lg, err = netBuf.WriteTo(t.conn)   // transport/connection.go
```

`net.Buffers.WriteTo` consumes the slice it is given, and `consume` nils out each element **inside the caller's backing array**:

```go
// net/net.go
func (v *Buffers) consume(n int64) {
	for len(*v) > 0 {
		ln0 := int64(len((*v)[0]))
		if ln0 > n {
			(*v)[0] = (*v)[0][n:]
			return
		}
		n -= ln0
		(*v)[0] = nil        // <- the caller's slice element becomes nil
		*v = (*v)[1:]
	}
}
```

So a caller that reuses a batch gets nothing written from the second call on - and still gets `nil` back, with `(0, nil)`:

```go
pkgs := [][]byte{[]byte("hello"), []byte("world")}
conn.Send(pkgs)  // lg=10, nil   -> len(pkgs[0]) is now 0
conn.Send(pkgs)  // lg=0,  nil   -> silently writes nothing
```

`Send` now copies the slice headers into scratch space taken from a `sync.Pool`, so only this connection's copy is consumed. Payloads are still written by reference, and the batched path keeps its allocation profile - verified with `BenchmarkSessionWriteBytesArray` on this branch: 4 / 5 / 5 allocs/op for 1 / 4 / 16 pkgs, identical to before.

## 2. A websocket client never got the `maxMsgLen` its callback asked for (issue #126)

`dialWS` / `dialWSS` did this **before** `NewSessionCallback` ran:

```go
ss = newWSSession(conn, c)
if ss.(*session).maxMsgLen > 0 {
	conn.SetReadLimit(int64(ss.(*session).maxMsgLen))   // still the 4KB default
}
```

`maxMsgLen` defaults to `maxReadBufLen` (4KB), the callback is the documented place to raise it, and gorilla's read limit can only change before the first read. The result: `SetMaxMsgLen` had no effect for ws clients, and any message above 4KB was rejected with `read limit exceeded` / close 1009. The server side already did it the other way round (`after newSession`); the fix applies the limit in `client.connect()` right after `newSession`, so it follows whatever the callback asked for.

## Tests

Both fail on master and pass here:

```
--- FAIL: TestConnectionSendBatchKeepsCallerBuffers
    Send call 1 consumed the caller's buffers: len(pkgs[0])=0 len(pkgs[1])=0, want 5 and 5

--- FAIL: TestWSClientReadLimitFollowsSetMaxMsgLen
    no echo for a payload above the 4KB default: the client read limit did not follow SetMaxMsgLen
```

`go test ./transport -race`, `make test`, `make check-fmt` and `make lint` are all green on this branch.
