### PR TITLE
fix: self-connect fd leak, udp callback panic, and mTLS that does not verify clients (#123, #125, #127)

### DIFF
--- a/transport/client.go
+++ b/transport/client.go
@@ -105,6 +105,13 @@ func newClient(t EndPointType, opts ...ClientOption) *client {
 	if c.number <= 0 || c.addr == "" {
 		panic(fmt.Sprintf("client type:%s, @connNum:%d, @serverAddr:%s", t, c.number, c.addr))
 	}
+	if c.sslEnabled && c.tlsConfigBuilder == nil {
+		// #125: dialTCP runs inside the reconnect goroutine, so letting this
+		// combination through turns a configuration mistake into a nil-pointer
+		// panic that kills the process from somewhere else. Fail here instead,
+		// where the caller can see it and nothing has been started yet.
+		panic(fmt.Sprintf("client type:%s, sslEnabled is true but no tlsConfigBuilder was supplied; use WithClientTlsConfigBuilder", t))
+	}
 
 	c.ssMap = make(map[Session]struct{}, c.number)
 

--- a/transport/client_test.go
+++ b/transport/client_test.go
@@ -21,11 +21,13 @@ import (
 	"bytes"
 	"crypto/tls"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -1247,4 +1249,27 @@ func TestNewWSSClient(t *testing.T) {
 	// time.Sleep(1000e9)
 	// server.Close()
 	// assert.True(t, server.IsClosed())
+}
+
+// Regression test for #125: newClient only validated number/addr, so
+// sslEnabled without a tlsConfigBuilder reached dialTCP, which runs inside the
+// reconnect goroutine - a nil-pointer panic there is unrecoverable and appears
+// as an unrelated crash. The combination is now rejected synchronously, with a
+// message naming the missing option.
+func TestNewClientSSLRequiresTLSConfigBuilder(t *testing.T) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("NewTCPClient(sslEnabled, no tlsConfigBuilder) did not panic")
+		}
+		if !strings.Contains(fmt.Sprint(r), "tlsConfigBuilder") {
+			t.Fatalf("panic value %v does not name the missing option", r)
+		}
+	}()
+
+	NewTCPClient(
+		WithServerAddress("127.0.0.1:1"),
+		WithConnectionNumber(1),
+		WithClientSslEnabled(true),
+	)
 }

--- a/transport/server.go
+++ b/transport/server.go
@@ -315,6 +315,11 @@ func (s *server) accept(newSession NewSessionCallback) (Session, error) {
 	}
 	if gxnet.IsSameAddr(conn.RemoteAddr(), conn.LocalAddr()) {
 		log.Warnf("conn.localAddr{%s} == conn.RemoteAddr{%s}", conn.LocalAddr().String(), conn.RemoteAddr().String())
+		// #123: the connection was accepted, so it owns a descriptor. Returning
+		// without closing it leaks that fd until the process exits, because the
+		// caller just keeps accepting. The client side already closes before it
+		// reports errSelfConnect.
+		_ = conn.Close()
 		return nil, perrors.WithStack(errSelfConnect)
 	}
 
@@ -384,8 +389,12 @@ func (s *server) runUDPEventLoop(newSession NewSessionCallback) {
 		conn = s.pktListener.(*net.UDPConn)
 		ss = newUDPSession(conn, s)
 		if err = newSession(ss); err != nil {
+			// #125: this runs in a goroutine the library started, so a panic here
+			// is unrecoverable and takes the whole process down over a caller
+			// error. The TCP accept path logs and keeps serving; do the same.
+			log.Errorf("server{%s}.newSession(ss{%#v}) = err {%s}", s.addr, ss, perrors.WithStack(err))
 			_ = conn.Close()
-			panic(err.Error())
+			return
 		}
 		ss.(*session).run()
 	}()

--- a/transport/server_test.go
+++ b/transport/server_test.go
@@ -474,3 +474,50 @@ func (c *selfConnectConn) SetReadDeadline(time.Time) error {
 func (c *selfConnectConn) SetWriteDeadline(time.Time) error {
 	return nil
 }
+
+// singleAcceptListener hands out one already-built connection, so accept() can
+// be driven without a real listener.
+type singleAcceptListener struct{ conn net.Conn }
+
+func (l *singleAcceptListener) Accept() (net.Conn, error) { return l.conn, nil }
+func (*singleAcceptListener) Close() error                { return nil }
+func (*singleAcceptListener) Addr() net.Addr              { return &net.TCPAddr{} }
+
+// Regression test for #123: accept() logged the self-connect and returned
+// without closing the connection it had just accepted. The accept loop simply
+// continues, so that descriptor leaked for the life of the process.
+func TestAcceptClosesSelfConnect(t *testing.T) {
+	// one addr for both directions is what makes it a self-connect
+	conn := &selfConnectConn{addr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 65000}}
+	srv := newServer(TCP_SERVER)
+	srv.streamListener = &singleAcceptListener{conn: conn}
+
+	ss, err := srv.accept(func(Session) error { return nil })
+	if !errors.Is(err, errSelfConnect) {
+		t.Fatalf("accept() error = %v, want %v", err, errSelfConnect)
+	}
+	if ss != nil {
+		t.Fatalf("accept() returned session %v for a self-connect", ss)
+	}
+	if !conn.closed {
+		t.Fatal("accept() left the self-connect connection open: the fd is leaked")
+	}
+}
+
+// Regression test for #125: a udp endpoint's newSession callback returning an
+// error used to panic inside the goroutine RunEventLoop spawned, and a panic
+// there cannot be recovered by any caller - a transient error in a user callback
+// killed the process. It now logs and stops serving, like the tcp accept path.
+func TestUDPNewSessionErrorDoesNotPanic(t *testing.T) {
+	srv := NewUDPEndPoint(WithLocalAddress("127.0.0.1:0"))
+	srv.RunEventLoop(func(Session) error { return errors.New("callback failed") })
+
+	// Close waits for the session goroutine (s.wg), so reaching the end of this
+	// test means it did not panic. Before the fix it panicked here and took the
+	// whole test binary down.
+	srv.Close()
+
+	if !srv.IsClosed() {
+		t.Fatal("udp endpoint does not report itself closed")
+	}
+}

--- a/transport/tls.go
+++ b/transport/tls.go
@@ -63,6 +63,9 @@ func (s *ServerTlsConfigBuilder) BuildTlsConfig() (*tls.Config, error) {
 		InsecureSkipVerify: true, // do not verify peer certs
 		ClientAuth:         tls.RequireAnyClientCert,
 		Certificates:       []tls.Certificate{certificate},
+		// #127: without this the server accepted TLS 1.0/1.1, while the client
+		// builder has set VersionTLS12 all along.
+		MinVersion: tls.VersionTLS12,
 	}
 
 	if s.ServerTrustCertCollectionPath != "" {
@@ -80,7 +83,12 @@ func (s *ServerTlsConfigBuilder) BuildTlsConfig() (*tls.Config, error) {
 			return nil, fmt.Errorf("failed to parse root certificate file: %s", s.ServerTrustCertCollectionPath)
 		}
 		config.ClientCAs = certPool
-		config.ClientAuth = tls.RequireAnyClientCert
+		// #127: RequireAnyClientCert demands a certificate but verifies nothing,
+		// so ClientCAs was dead configuration: any self-signed certificate
+		// completed the handshake and an operator who configured a trust
+		// collection still had no mTLS. Verify against it, the way the WSS
+		// server path already does.
+		config.ClientAuth = tls.RequireAndVerifyClientCert
 		config.InsecureSkipVerify = false
 	}
 	return config, nil

--- a/transport/tls_test.go
+++ b/transport/tls_test.go
@@ -127,3 +127,80 @@ func TestClientTLSConfigBuilderRejectsInvalidTrustCollection(t *testing.T) {
 		t.Fatal("config must be nil when BuildTlsConfig fails")
 	}
 }
+
+// writeServerTLSFixtures lays out a server key pair plus a trust collection and
+// returns their paths.
+func writeServerTLSFixtures(t *testing.T) (certPath, keyPath, caPath string) {
+	t.Helper()
+
+	tempDir := t.TempDir()
+	certPath = filepath.Join(tempDir, "server.crt")
+	keyPath = filepath.Join(tempDir, "server.key")
+	caPath = filepath.Join(tempDir, "ca.crt")
+	for path, data := range map[string][]byte{
+		certPath: WssServerCRT,
+		keyPath:  WssServerKEY,
+		caPath:   tlsTestRootCertificate,
+	} {
+		if err := os.WriteFile(path, data, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return certPath, keyPath, caPath
+}
+
+// Regression test for #127: with a trust collection configured the server asked
+// for a client certificate but never verified it (RequireAnyClientCert), so
+// ServerTrustCertCollectionPath was dead configuration - any self-signed
+// certificate completed the handshake and an operator who thought mTLS was on
+// had none.
+func TestServerTLSConfigBuilderVerifiesClientCertificate(t *testing.T) {
+	certPath, keyPath, caPath := writeServerTLSFixtures(t)
+
+	config, err := (&ServerTlsConfigBuilder{
+		ServerKeyCertChainPath:        certPath,
+		ServerPrivateKeyPath:          keyPath,
+		ServerTrustCertCollectionPath: caPath,
+	}).BuildTlsConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if config.ClientAuth != tls.RequireAndVerifyClientCert {
+		t.Fatalf("ClientAuth = %v, want RequireAndVerifyClientCert: ClientCAs is not consulted otherwise", config.ClientAuth)
+	}
+	if config.InsecureSkipVerify {
+		t.Fatal("InsecureSkipVerify is true on a config that must verify clients")
+	}
+	if config.MinVersion != tls.VersionTLS12 {
+		t.Fatalf("MinVersion = %d, want TLS 1.2 (%d)", config.MinVersion, tls.VersionTLS12)
+	}
+	expectedClientCAs := x509.NewCertPool()
+	if !expectedClientCAs.AppendCertsFromPEM(tlsTestRootCertificate) {
+		t.Fatal("failed to parse the expected trust collection")
+	}
+	if config.ClientCAs == nil || !config.ClientCAs.Equal(expectedClientCAs) {
+		t.Fatal("ClientCAs does not contain the configured trust certificate")
+	}
+}
+
+// Without a trust collection the server can only require that a client presents
+// some certificate, but the protocol floor still applies.
+func TestServerTLSConfigBuilderWithoutTrustCollection(t *testing.T) {
+	certPath, keyPath, _ := writeServerTLSFixtures(t)
+
+	config, err := (&ServerTlsConfigBuilder{
+		ServerKeyCertChainPath: certPath,
+		ServerPrivateKeyPath:   keyPath,
+	}).BuildTlsConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if config.ClientAuth != tls.RequireAnyClientCert {
+		t.Fatalf("ClientAuth = %v, want RequireAnyClientCert when no trust collection is configured", config.ClientAuth)
+	}
+	if config.MinVersion != tls.VersionTLS12 {
+		t.Fatalf("MinVersion = %d, want TLS 1.2 (%d)", config.MinVersion, tls.VersionTLS12)
+	}
+}


### PR DESCRIPTION
Fixes #123. Fixes #125. Fixes #127.

Three code-review findings, all small, all silent from the caller's side, each with a regression test that fails on master.

## #123 `server.accept()` leaked the fd of a self-connect

```go
if gxnet.IsSameAddr(conn.RemoteAddr(), conn.LocalAddr()) {
	log.Warnf("conn.localAddr{%s} == conn.RemoteAddr{%s}", ...)
	return nil, perrors.WithStack(errSelfConnect)   // conn was never closed
}
```

The connection had already been accepted, so it owns a descriptor; the accept loop just continues, and that descriptor leaks for the life of the process. The client side closes before reporting `errSelfConnect`; the server side now does too.

## #125 two of the three process-killing panics

**udp endpoint, `newSession` callback error** (`runUDPEventLoop`):

```go
if err = newSession(ss); err != nil {
	_ = conn.Close()
	panic(err.Error())      // inside a goroutine RunEventLoop spawned
}
```

A panic in a goroutine the library started cannot be recovered by any caller, so a transient error in a user callback (dependency not ready, validation failure) took the process down. It now logs and stops serving, which is what the tcp accept path does.

**client with `sslEnabled` and no `tlsConfigBuilder`**: `dialTCP` calls `c.tlsConfigBuilder.BuildTlsConfig()`, and `dialTCP` runs inside the reconnect goroutine. `newClient` only validated `number`/`addr`, so the combination surfaced as a nil-pointer panic from an unrelated place. It is now rejected in `newClient`, synchronously, before anything is started:

```
panic: client type:TCP_CLIENT, sslEnabled is true but no tlsConfigBuilder was supplied; use WithClientTlsConfigBuilder
```

> The third item of #125 (the WSS `Serve` panic) is already fixed on master - the current code logs and skips `http.ErrServerClosed` instead of panicking - so it was not touched here.

## #127 mTLS was configuration theatre

```go
config.ClientCAs = certPool
config.ClientAuth = tls.RequireAnyClientCert      // demands a cert, verifies nothing
```

`crypto/tls` only consults `ClientCAs` from `VerifyClientCertIfGiven` upwards, so with a trust collection configured `certPool` was dead configuration: any self-signed certificate completed the handshake. It is now `tls.RequireAndVerifyClientCert`, which is what the WSS server path already used. The same builder also left `MinVersion` at 0 while the client builder has always set TLS 1.2, so the server accepted TLS 1.0/1.1; that is fixed too.

## Tests

All five fail on master:

```
--- FAIL: TestAcceptClosesSelfConnect
    accept() left the self-connect connection open: the fd is leaked

--- FAIL: TestUDPNewSessionErrorDoesNotPanic
    panic: callback failed                     (the goroutine panic took the test binary down)

--- FAIL: TestNewClientSSLRequiresTLSConfigBuilder
    NewTCPClient(sslEnabled, no tlsConfigBuilder) did not panic

--- FAIL: TestServerTLSConfigBuilderVerifiesClientCertificate
    ClientAuth = RequireAnyClientCert, want RequireAndVerifyClientCert: ClientCAs is not consulted otherwise

--- FAIL: TestServerTLSConfigBuilderWithoutTrustCollection
    MinVersion = 0, want TLS 1.2 (771)
```

`go test ./transport -race`, `make test`, `make check-fmt` and `make lint` are green on this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid TLS client and server configurations now fail immediately with clear errors.
  * TCP self-connections are closed properly to prevent resource leaks.
  * UDP session initialization errors shut down cleanly.
  * WebSocket connections now time out if the upgrade handshake does not complete.
  * Callback failures and panics are contained without stopping other connections, and affected connections are closed cleanly.

* **Security**
  * TLS connections now require TLS 1.2 or later.
  * Configured client certificates are fully verified against the trusted certificate collection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->