### PR TITLE
perf: skip the per-write debug log when debug is off (-7.5% on the tcp write path, -57% allocations)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ test: clean
 	GOTOOLCHAIN=go1.25.0+auto go test ./... -count=1 -coverprofile=coverage.txt -covermode=atomic
 
 test-race:
-	GOTOOLCHAIN=go1.25.0+auto go test -race ./transport -count=1
+	GOTOOLCHAIN=go1.25.0+auto go test -race ./transport ./util -count=1
 
 fmt: install-imports-formatter
 	go fmt ./... && GOROOT=$(shell go env GOROOT) imports-formatter

--- a/transport/connection.go
+++ b/transport/connection.go
@@ -821,8 +821,10 @@ func (t *gettyTCPConn) Send(pkg any) (int, error) {
 			t.writeBytes.Add((uint32)(lg))
 			t.writePkgNum.Add((uint32)(len(buffers)))
 		}
-		log.Debugf("localAddr: %s, remoteAddr:%s, length:%d, err:%v",
-			t.conn.LocalAddr(), t.conn.RemoteAddr(), lg, err)
+		if log.IsDebugEnabled() {
+			log.Debugf("localAddr: %s, remoteAddr:%s, length:%d, err:%v",
+				t.conn.LocalAddr(), t.conn.RemoteAddr(), lg, err)
+		}
 		return int(lg), t.codecIOError(err)
 	}
 
@@ -832,8 +834,10 @@ func (t *gettyTCPConn) Send(pkg any) (int, error) {
 			t.writeBytes.Add((uint32)(len(p)))
 			t.writePkgNum.Add(1)
 		}
-		log.Debugf("localAddr: %s, remoteAddr:%s, length:%d, err:%v",
-			t.conn.LocalAddr(), t.conn.RemoteAddr(), length, err)
+		if log.IsDebugEnabled() {
+			log.Debugf("localAddr: %s, remoteAddr:%s, length:%d, err:%v",
+				t.conn.LocalAddr(), t.conn.RemoteAddr(), length, err)
+		}
 		return length, t.codecIOError(err)
 	}
 
@@ -960,7 +964,9 @@ func (u *gettyUDPConn) recv(p []byte) (int, *net.UDPAddr, error) {
 	}
 
 	length, addr, err := u.conn.ReadFromUDP(p) // connected udp also can get return @addr
-	log.Debugf("ReadFromUDP(p:%d) = {length:%d, peerAddr:%s, error:%v}", len(p), length, addr, err)
+	if log.IsDebugEnabled() {
+		log.Debugf("ReadFromUDP(p:%d) = {length:%d, peerAddr:%s, error:%v}", len(p), length, addr, err)
+	}
 	if err == nil {
 		u.readBytes.Add(uint32(length))
 	}
@@ -1007,7 +1013,9 @@ func (u *gettyUDPConn) Send(udpCtx any) (int, error) {
 		u.writeBytes.Add((uint32)(len(buf)))
 		u.writePkgNum.Add(1)
 	}
-	log.Debugf("WriteMsgUDP(peerAddr:%s) = {length:%d, error:%v}", peerAddr, length, err)
+	if log.IsDebugEnabled() {
+		log.Debugf("WriteMsgUDP(peerAddr:%s) = {length:%d, error:%v}", peerAddr, length, err)
+	}
 
 	return length, perrors.WithStack(err)
 }

--- a/transport/connection_test.go
+++ b/transport/connection_test.go
@@ -25,6 +25,7 @@ import (
 	"io"
 	"net"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -33,6 +34,10 @@ import (
 	"github.com/golang/snappy"
 
 	perrors "github.com/pkg/errors"
+)
+
+import (
+	gettylog "github.com/AlexStocks/getty/util"
 )
 
 type blockingSnappyWriter struct {
@@ -1040,5 +1045,64 @@ func TestCodecSendStallDetectionOutrunsLongPollInterval(t *testing.T) {
 			}
 			assertCodecStreamBroken(t, err)
 		})
+	}
+}
+
+// debugCountingLogger counts the debug calls getty passes to it.
+type debugCountingLogger struct{ debugfCalls int32 }
+
+func (*debugCountingLogger) Info(...any)           {}
+func (*debugCountingLogger) Warn(...any)           {}
+func (*debugCountingLogger) Error(...any)          {}
+func (*debugCountingLogger) Debug(...any)          {}
+func (*debugCountingLogger) Infof(string, ...any)  {}
+func (*debugCountingLogger) Warnf(string, ...any)  {}
+func (*debugCountingLogger) Errorf(string, ...any) {}
+
+func (l *debugCountingLogger) Debugf(string, ...any) {
+	atomic.AddInt32(&l.debugfCalls, 1)
+}
+
+// TestConnectionSendSkipsDebugLoggingWhenDisabled pins the per-write cost of the
+// debug log. Send logs every write with `...any` arguments, and those are boxed
+// at the call site, so a Debugf that the level discards still cost one
+// allocation (the []any backing array) per write - measured on the benchmarks in
+// ./benchmark as 112 B/op -> 48 B/op and about 7.5% of the tcp write path.
+//
+// The contract asserted here is the observable one: with debug disabled, getty
+// must not build the log record at all.
+func TestConnectionSendSkipsDebugLoggingWhenDisabled(t *testing.T) {
+	previousLogger := gettylog.GetLogger()
+	wasDebugEnabled := gettylog.IsDebugEnabled()
+
+	// level first: SetLoggerLevel installs the built-in sugared logger
+	if err := gettylog.SetLoggerLevel(gettylog.LoggerLevelWarn); err != nil {
+		t.Fatal(err)
+	}
+	recorder := &debugCountingLogger{}
+	gettylog.SetLogger(recorder)
+
+	t.Cleanup(func() {
+		gettylog.SetLogger(previousLogger)
+		level := gettylog.LoggerLevelWarn
+		if wasDebugEnabled {
+			level = gettylog.LoggerLevelDebug
+		}
+		if err := gettylog.SetLoggerLevel(level); err != nil {
+			t.Error(err)
+		}
+	})
+
+	if gettylog.IsDebugEnabled() {
+		t.Fatal("debug is still enabled; this test needs it off")
+	}
+
+	conn := newGettyTCPConn(&timeoutAccessorNetConn{})
+	if _, err := conn.Send([]byte("payload")); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := atomic.LoadInt32(&recorder.debugfCalls); got != 0 {
+		t.Fatalf("Send built %d debug records with debug disabled, want 0: the ...any arguments are boxed before the level is consulted, which cost one allocation per write", got)
 	}
 }

--- a/transport/connection_test.go
+++ b/transport/connection_test.go
@@ -1073,9 +1073,10 @@ func (l *debugCountingLogger) Debugf(string, ...any) {
 // must not build the log record at all.
 func TestConnectionSendSkipsDebugLoggingWhenDisabled(t *testing.T) {
 	previousLogger := gettylog.GetLogger()
-	wasDebugEnabled := gettylog.IsDebugEnabled()
+	previousLevel := gettylog.GetLoggerLevel()
 
-	// level first: SetLoggerLevel installs the built-in sugared logger
+	// level first: SetLoggerLevel installs the built-in sugared logger, so the
+	// recorder has to be installed after it
 	if err := gettylog.SetLoggerLevel(gettylog.LoggerLevelWarn); err != nil {
 		t.Fatal(err)
 	}
@@ -1083,14 +1084,12 @@ func TestConnectionSendSkipsDebugLoggingWhenDisabled(t *testing.T) {
 	gettylog.SetLogger(recorder)
 
 	t.Cleanup(func() {
-		gettylog.SetLogger(previousLogger)
-		level := gettylog.LoggerLevelWarn
-		if wasDebugEnabled {
-			level = gettylog.LoggerLevelDebug
-		}
-		if err := gettylog.SetLoggerLevel(level); err != nil {
+		// same order on the way out: the level restores the built-in logger, and
+		// the saved logger goes back last, so both are exactly what they were
+		if err := gettylog.SetLoggerLevel(previousLevel); err != nil {
 			t.Error(err)
 		}
+		gettylog.SetLogger(previousLogger)
 	})
 
 	if gettylog.IsDebugEnabled() {

--- a/transport/session.go
+++ b/transport/session.go
@@ -1003,7 +1003,9 @@ func (s *session) handleUDPPackage() error {
 	for !s.IsClosed() {
 
 		bufLen, addr, err = conn.recv(buf)
-		log.Debugf("conn.read() = bufLen:%d, addr:%#v, err:%+v", bufLen, addr, perrors.WithStack(err))
+		if log.IsDebugEnabled() {
+			log.Debugf("conn.read() = bufLen:%d, addr:%#v, err:%+v", bufLen, addr, perrors.WithStack(err))
+		}
 		if netError, ok = perrors.Cause(err).(net.Error); ok && netError.Timeout() {
 			continue
 		}
@@ -1025,7 +1027,9 @@ func (s *session) handleUDPPackage() error {
 		}
 
 		pkg, pkgLen, err = s.reader.Read(s, buf[:bufLen])
-		log.Debugf("s.reader.Read() = pkg:%#v, pkgLen:%d, err:%+v", pkg, pkgLen, perrors.WithStack(err))
+		if log.IsDebugEnabled() {
+			log.Debugf("s.reader.Read() = pkg:%#v, pkgLen:%d, err:%+v", pkg, pkgLen, perrors.WithStack(err))
+		}
 		if err == nil && s.maxMsgLen > 0 && bufLen > int(s.maxMsgLen) {
 			err = perrors.Errorf("Message Too Long, bufLen %d, session max message len %d", bufLen, s.maxMsgLen)
 		}

--- a/util/logger.go
+++ b/util/logger.go
@@ -132,6 +132,13 @@ func IsDebugEnabled() bool {
 	return zapLoggerConfig.Level.Enabled(zapcore.DebugLevel)
 }
 
+// GetLoggerLevel returns the level configured through SetLoggerLevel, so a
+// caller can restore it exactly. Like IsDebugEnabled it describes the built-in
+// logger; a logger installed with SetLogger does not report its own level here.
+func GetLoggerLevel() LoggerLevel {
+	return LoggerLevel(zapLoggerConfig.Level.Level())
+}
+
 // SetLoggerCallerDisable disable caller info in production env for performance improve.
 // It is highly recommended that you execute this method in a production environment.
 func SetLoggerCallerDisable() error {

--- a/util/logger.go
+++ b/util/logger.go
@@ -106,10 +106,19 @@ func GetLogger() Logger {
 	return log
 }
 
-// SetLoggerLevel set logger level
+// SetLoggerLevel set logger level.
+//
+// It rebuilds and installs the built-in sugared logger, so a logger previously
+// installed with SetLogger is replaced - the level of a custom logger cannot be
+// set through here.
 func SetLoggerLevel(level LoggerLevel) error {
 	var err error
-	zapLoggerConfig.Level = zap.NewAtomicLevelAt(zapcore.Level(level))
+	// Mutate the existing AtomicLevel instead of assigning a new one: the field
+	// is read by IsDebugEnabled/GetLoggerLevel from other goroutines (both sit
+	// on the per-connection paths), and replacing it would race with those reads.
+	// AtomicLevel exists to be updated in place; Build() still has to run to
+	// rebuild the logger the new level applies to.
+	zapLoggerConfig.Level.SetLevel(zapcore.Level(level))
 	zapLogger, err = zapLoggerConfig.Build()
 	if err != nil {
 		return err

--- a/util/logger.go
+++ b/util/logger.go
@@ -118,6 +118,20 @@ func SetLoggerLevel(level LoggerLevel) error {
 	return nil
 }
 
+// IsDebugEnabled reports whether debug records are currently written.
+//
+// A caller on a hot path uses it to skip building log arguments: variadic
+// ...any arguments are boxed at the call site, so a Debugf that the level
+// discards still costs an allocation per call. gettyTCPConn.Send logs every
+// write, which made that a per-packet cost.
+//
+// It reports the level configured through SetLoggerLevel. A logger installed
+// with SetLogger is opaque here - it does not report its level - so this returns
+// the level of the built-in logger in that case.
+func IsDebugEnabled() bool {
+	return zapLoggerConfig.Level.Enabled(zapcore.DebugLevel)
+}
+
 // SetLoggerCallerDisable disable caller info in production env for performance improve.
 // It is highly recommended that you execute this method in a production environment.
 func SetLoggerCallerDisable() error {

--- a/util/logger_test.go
+++ b/util/logger_test.go
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package getty
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestLoggerLevelAccessorsAreRaceFree drives SetLoggerLevel against the level
+// getters from two goroutines. SetLoggerLevel used to assign a fresh
+// zap.AtomicLevel to zapLoggerConfig.Level while IsDebugEnabled/GetLoggerLevel
+// read that field - a data race on the field itself, reachable from any
+// management thread because IsDebugEnabled sits on the per-connection paths.
+// AtomicLevel is now updated in place, so both sides go through atomics.
+//
+// The race detector is the point of this test: it is green on the broken code
+// unless something drives both directions at once, which is why the race job
+// needs to cover this package.
+func TestLoggerLevelAccessorsAreRaceFree(t *testing.T) {
+	const iterations = 2000
+
+	previous := GetLoggerLevel()
+	t.Cleanup(func() {
+		if err := SetLoggerLevel(previous); err != nil {
+			t.Error(err)
+		}
+	})
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			if err := SetLoggerLevel(LoggerLevelInfo); err != nil {
+				t.Error(err)
+				return
+			}
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			_ = IsDebugEnabled()
+			_ = GetLoggerLevel()
+		}
+	}()
+	wg.Wait()
+}


### PR DESCRIPTION
Found while building the benchmarks in #143 - the per-write debug record turned out to be the largest single cost in the write path.

## The cost

`gettyTCPConn.Send` logs every write:

```go
log.Debugf("localAddr: %s, remoteAddr:%s, length:%d, err:%v",
	t.conn.LocalAddr(), t.conn.RemoteAddr(), length, err)
```

The `...any` arguments are boxed **at the call site**, so a record the configured level discards still costs one allocation - the `[]any` backing array - on every write. The same pattern sits on the udp send path, the udp receive path, and twice inside the udp package loop.

## The fix

`util.IsDebugEnabled()` reports the level configured through `SetLoggerLevel`, and those six per-operation records are now guarded by it:

```go
if log.IsDebugEnabled() {
	log.Debugf("localAddr: %s, remoteAddr:%s, length:%d, err:%v", ...)
}
```

`IsDebugEnabled` is a package function rather than a method on the `Logger` interface on purpose: adding a method to that interface would break every implementation outside the module. It reports the level of the built-in logger, so a logger installed through `SetLogger` is opaque to it - that caveat is in the doc comment.

## Measurements

Against `upstream/master`, with the benchmarks from #143 (`-benchtime=1s -count=5`, Apple M1), on the 64-byte payload where the per-write cost dominates:

```
                            sec/op                  B/op
  SessionWriteBytes/64  2.246us -> 2.078us  -7.48%  112 ->  48  -57%
  SessionSend/64        2.236us -> 2.066us  -7.60%  112 ->  48  -57%
  UDPSend/64            2.164us -> 2.105us  -2.73%  148 -> 100  -32%
```

(All three `p=0.008`, `n=5`; the B/op difference is exactly the one boxed `[]any` per call.)

And under an external load generator - 100 connections of 6-byte messages against the standalone server from #143 - leaving debug logging on costs about **4x** on the echo path:

```
-log_level error:  362k-451k msg/s
-log_level debug:   77k-100k msg/s      (2.28 million log lines in 15 seconds)
```

## Test

The regression test asserts the observable contract instead of an allocation count: with the level at `warn`, a recording logger installed through `SetLogger` must receive **no** debug records from `Send`. On master it fails with

```
Send built 1 debug records with debug disabled, want 0: the ...any arguments are boxed before the level is consulted, which cost one allocation per write
```

`go test ./transport -race`, `go test ./...`, `make check-fmt` and `make lint` are green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Reduced unnecessary debug-log formatting and processing when debug logging is disabled for TCP and UDP transport activity.

* **Reliability**
  * Improved logger configuration and replacement behavior when logging is accessed or changed concurrently.

* **Tests**
  * Added coverage confirming disabled debug logging avoids unnecessary operations and logger settings are restored correctly.
  * Expanded race-detector coverage for transport and logging components, including concurrent logger updates and log calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->